### PR TITLE
feat(compat): add elevenlabs-compatible TTS endpoints (/elevenlabs)

### DIFF
--- a/docs/api-compatibility.md
+++ b/docs/api-compatibility.md
@@ -43,3 +43,31 @@ curl -X POST \
 `output_format` values: `mp3_44100_128`, `pcm_16000`, `ulaw_8000`, etc. Falls back to WAV if pydub absent.
 
 ---
+
+### Pointing apps at this server
+
+ElevenLabs SDKs accept a custom base URL. Point it at `http://localhost:9666/elevenlabs`.
+
+**Python SDK** ([`elevenlabs`](https://github.com/elevenlabs/elevenlabs-python)):
+```python
+from elevenlabs.client import ElevenLabs
+client = ElevenLabs(api_key="ignored", base_url="http://localhost:9666/elevenlabs")
+```
+
+**Environment variable** (community convention used by many apps):
+```bash
+export ELEVENLABS_BASE_URL=http://localhost:9666/elevenlabs
+export ELEVENLABS_API_KEY=ignored
+```
+
+**Node SDK** (`@elevenlabs/elevenlabs-js`):
+```js
+new ElevenLabsClient({ apiKey: "ignored", baseUrl: "http://localhost:9666/elevenlabs" });
+```
+
+**curl**:
+```bash
+curl -X POST -H "xi-api-key: x" -H "Content-Type: application/json" \
+  -d '{"text": "hello"}' \
+  "http://localhost:9666/elevenlabs/v1/text-to-speech/default" -o out.mp3
+```

--- a/docs/api-compatibility.md
+++ b/docs/api-compatibility.md
@@ -19,6 +19,12 @@ Other vendor sections are added by their respective compat-router PRs.
 
 ## ElevenLabs (`/elevenlabs`)
 
+**Upstream sources**:
+- Python SDK: [elevenlabs/elevenlabs-python](https://github.com/elevenlabs/elevenlabs-python) — `text_to_speech.convert()` builds `POST /v1/text-to-speech/{voice_id}`
+- API reference: [ElevenLabs Text-to-Speech docs](https://elevenlabs.io/docs/api-reference/text-to-speech)
+- Node SDK: [elevenlabs/elevenlabs-js](https://github.com/elevenlabs/elevenlabs-js)
+
+
 | Method | Path | Description |
 | :--- | :--- | :--- |
 | GET | `/elevenlabs/v1/voices` | List available voices |

--- a/docs/api-compatibility.md
+++ b/docs/api-compatibility.md
@@ -1,9 +1,45 @@
-# Third-Party API Compatibility
+# API Compatibility Reference
 
-`ovos-tts-server` can expose its underlying OVOS TTS plugin behind drop-in compatibility endpoints for popular cloud TTS APIs. This lets existing apps that already speak a vendor's HTTP API use OVOS as a drop-in replacement — no client code changes required.
+`ovos-tts-server` exposes its underlying OVOS TTS plugin behind drop-in
+compatibility endpoints for popular cloud TTS APIs. Each vendor lives
+under its own URL prefix so multiple compat layers coexist with no path
+collisions.
 
-Each vendor's endpoints live under a dedicated URL prefix so multiple compat layers can coexist in one FastAPI app with no path collisions. Concrete vendor sections (request schema, query params, response shape, curl examples) are added by each compat-router PR as it lands.
+All routers accept any auth token / API key from the client and silently
+ignore it — authentication is the responsibility of your reverse proxy.
 
-All routers accept any auth token / API key supplied by the client and silently ignore it — authentication is the responsibility of your reverse proxy.
+Audio format conversion is provided by `ovos_tts_server.audio_utils.convert_audio()`.
+Install the `[audio]` extra (`pip install ovos-tts-server[audio]`) to enable
+non-WAV outputs via `pydub`.
 
-Audio format conversion across `wav`, `mp3`, `ogg`, `flac`, `pcm`, etc. is provided by `ovos_tts_server.audio_utils.convert_audio()`. Install the `[audio]` extra (`pip install ovos-tts-server[audio]`) to enable non-WAV outputs via `pydub`.
+This document currently covers: **ElevenLabs (`/elevenlabs`)**.
+Other vendor sections are added by their respective compat-router PRs.
+
+---
+
+## ElevenLabs (`/elevenlabs`)
+
+| Method | Path | Description |
+| :--- | :--- | :--- |
+| GET | `/elevenlabs/v1/voices` | List available voices |
+| GET | `/elevenlabs/v1/models` | List available models |
+| POST | `/elevenlabs/v1/text-to-speech/{voice_id}` | Synthesize speech |
+
+**Auth:** `xi-api-key` header (ignored).
+
+```bash
+# List voices
+curl -H "xi-api-key: fake" http://localhost:9666/elevenlabs/v1/voices
+
+# Synthesize
+curl -X POST \
+  -H "xi-api-key: fake" \
+  -H "Content-Type: application/json" \
+  -d '{"text": "hello world"}' \
+  "http://localhost:9666/elevenlabs/v1/text-to-speech/default?output_format=mp3_44100_128" \
+  -o out.mp3
+```
+
+`output_format` values: `mp3_44100_128`, `pcm_16000`, `ulaw_8000`, etc. Falls back to WAV if pydub absent.
+
+---

--- a/examples/elevenlabs_example.py
+++ b/examples/elevenlabs_example.py
@@ -1,0 +1,37 @@
+"""Drive the official ElevenLabs SDK against an ovos-tts-server instance.
+
+The SDK accepts `base_url=` cleanly — no monkey-patching needed.
+
+Prerequisites:
+    pip install elevenlabs
+    ovos-tts-server --engine <some-ovos-tts-plugin> --port 9666
+
+Usage:
+    python examples/elevenlabs_example.py "hello world" out.mp3
+"""
+import sys
+
+from elevenlabs.client import ElevenLabs
+
+
+OVOS_HOST = "http://localhost:9666"
+
+
+def main(text: str, out_path: str) -> None:
+    client = ElevenLabs(base_url=f"{OVOS_HOST}/elevenlabs", api_key="ignored")
+    audio_iter = client.text_to_speech.convert(
+        voice_id="default",
+        text=text,
+        model_id="eleven_monolingual_v1",
+    )
+    with open(out_path, "wb") as fp:
+        for chunk in audio_iter:
+            if chunk:
+                fp.write(chunk)
+    print(f"wrote {out_path}")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        sys.exit(f"usage: {sys.argv[0]} <text> <out.mp3>")
+    main(sys.argv[1], sys.argv[2])

--- a/ovos_tts_server/__init__.py
+++ b/ovos_tts_server/__init__.py
@@ -135,6 +135,9 @@ def create_app(tts_engine: TTSEngineWrapper) -> FastAPI:
         audio_path, _ = tts_engine.synthesize(utterance, **plugin_params)
         return FileResponse(audio_path)
 
+    from ovos_tts_server.routers.elevenlabs import make_elevenlabs_router
+    app.include_router(make_elevenlabs_router(tts_engine))
+
     return app
 
 

--- a/ovos_tts_server/routers/elevenlabs.py
+++ b/ovos_tts_server/routers/elevenlabs.py
@@ -1,0 +1,165 @@
+# Licensed under the Apache License, Version 2.0
+"""ElevenLabs-compatible TTS endpoints."""
+from typing import List, Optional
+
+from fastapi import APIRouter, Header, Query
+from fastapi.responses import Response
+from pydantic import BaseModel, Field
+
+from ovos_tts_server.audio_utils import convert_audio
+
+
+class ElevenLabsVoice(BaseModel):
+    """ElevenLabs voice descriptor."""
+
+    voice_id: str = Field(..., min_length=1)
+    name: str = Field(..., min_length=1)
+
+
+class ElevenLabsVoicesResponse(BaseModel):
+    """Response for GET /v1/voices."""
+
+    voices: List[ElevenLabsVoice]
+
+
+class ElevenLabsVoiceSettings(BaseModel):
+    """Optional voice settings in ElevenLabs TTS request."""
+
+    stability: Optional[float] = Field(default=None, ge=0.0, le=1.0)
+    similarity_boost: Optional[float] = Field(default=None, ge=0.0, le=1.0)
+    style: Optional[float] = Field(default=None, ge=0.0, le=1.0)
+    use_speaker_boost: Optional[bool] = None
+
+
+class ElevenLabsTTSRequest(BaseModel):
+    """Request body for POST /v1/text-to-speech/{voice_id}."""
+
+    text: str = Field(..., min_length=1)
+    model_id: Optional[str] = Field(default="eleven_monolingual_v1", min_length=1)
+    voice_settings: Optional[ElevenLabsVoiceSettings] = None
+
+
+class ElevenLabsLanguage(BaseModel):
+    """Language entry in an ElevenLabs model descriptor."""
+
+    language_id: str = Field(..., min_length=1)
+    name: str = Field(..., min_length=1)
+
+
+class ElevenLabsModel(BaseModel):
+    """Model descriptor returned by GET /v1/models."""
+
+    model_id: str = Field(..., min_length=1)
+    name: str = Field(..., min_length=1)
+    description: str
+    languages: List[ElevenLabsLanguage]
+    can_be_finetuned: bool
+    can_do_text_to_speech: bool
+    can_do_voice_conversion: bool
+    can_use_style: bool
+    can_use_speaker_boost: bool
+    serves_pro_voices: bool
+    token_cost_factor: float = Field(..., ge=0.0)
+    requires_alpha_access: bool
+    max_characters_request_free_user: int = Field(..., ge=0)
+    max_characters_request_subscribed_user: int = Field(..., ge=0)
+
+
+def make_elevenlabs_router(engine) -> APIRouter:
+    """Create ElevenLabs-compatible router.
+
+    Args:
+        engine: TTSEngineWrapper instance.
+
+    Returns:
+        Configured APIRouter with ElevenLabs-compatible endpoints.
+    """
+    router = APIRouter(prefix="/elevenlabs", tags=["elevenlabs"])
+
+    @router.get("/v1/voices", response_model=ElevenLabsVoicesResponse)
+    def list_voices(
+            xi_api_key: Optional[str] = Header(default=None, alias="xi-api-key"),
+    ) -> ElevenLabsVoicesResponse:
+        """List available voices (ElevenLabs-compatible).
+
+        Returns:
+            ElevenLabsVoicesResponse: Available voices mapped from plugin.
+        """
+        raw = engine.voices
+        if raw:
+            voices = [
+                ElevenLabsVoice(
+                    voice_id=str(v) if not isinstance(v, dict) else v.get("id", str(v)),
+                    name=str(v) if not isinstance(v, dict) else v.get("name", str(v)),
+                )
+                for v in raw
+            ]
+        else:
+            voices = [ElevenLabsVoice(voice_id="default", name="default")]
+        return ElevenLabsVoicesResponse(voices=voices)
+
+    @router.post("/v1/text-to-speech/{voice_id}")
+    def tts_elevenlabs(
+            voice_id: str,
+            request: ElevenLabsTTSRequest,
+            output_format: str = Query(default="mp3_44100_128", alias="output_format"),
+            xi_api_key: Optional[str] = Header(default=None, alias="xi-api-key"),
+    ) -> Response:
+        """Synthesize speech (ElevenLabs-compatible).
+
+        Args:
+            voice_id: Voice identifier passed as voice kwarg to plugin.
+            request: TTS request body with text and optional settings.
+            output_format: ElevenLabs output_format string (e.g. "mp3_44100_128").
+            xi_api_key: API key header (accepted, ignored).
+
+        Returns:
+            Audio response in requested format.
+        """
+        fmt = "mp3"
+        if output_format.startswith("pcm"):
+            fmt = "pcm"
+        elif output_format.startswith("ulaw"):
+            fmt = "wav"
+        elif "_" in output_format:
+            fmt = output_format.split("_")[0]
+
+        synth_kwargs = {}
+        if voice_id and voice_id != "default":
+            synth_kwargs["voice"] = voice_id
+
+        audio_path, _ = engine.synthesize(request.text, **synth_kwargs)
+        audio_bytes, mime = convert_audio(audio_path, fmt)
+        return Response(content=audio_bytes, media_type=mime)
+
+    @router.get("/v1/models", response_model=List[ElevenLabsModel])
+    def list_models(
+            xi_api_key: Optional[str] = Header(default=None, alias="xi-api-key"),
+    ) -> List[ElevenLabsModel]:
+        """List available models (ElevenLabs-compatible).
+
+        Returns:
+            List of ElevenLabsModel descriptors for the loaded plugin.
+        """
+        return [
+            ElevenLabsModel(
+                model_id=engine.plugin_name,
+                name=engine.plugin_name,
+                description="OVOS TTS Plugin",
+                languages=[
+                    ElevenLabsLanguage(language_id=lang, name=lang) for lang in engine.langs
+                ],
+                can_be_finetuned=False,
+                can_do_text_to_speech=True,
+                can_do_voice_conversion=False,
+                can_use_style=False,
+                can_use_speaker_boost=False,
+                serves_pro_voices=False,
+                token_cost_factor=1.0,
+                requires_alpha_access=False,
+                max_characters_request_free_user=10000,
+                max_characters_request_subscribed_user=10000,
+            )
+        ]
+
+    return router

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -1,0 +1,79 @@
+"""Shared fixtures for integration tests.
+
+Each integration test runs the compat router(s) behind a real uvicorn
+server on a random local port, then drives it with the vendor's official
+SDK to prove drop-in compatibility.
+
+Tests skip automatically when the vendor SDK isn't installed; install
+them with `pip install -e .[live]`.
+"""
+import socket
+import tempfile
+import threading
+import time
+import wave
+from typing import List, Optional, Tuple
+
+import pytest
+
+
+class FakeEngine:
+    """Stand-in for TTSEngineWrapper; produces a valid silent WAV."""
+
+    plugin_name: str = "fake-tts"
+    lang: str = "en-us"
+    langs: List[str] = ["en-us", "de-de"]
+    voices: List[str] = ["voice1", "voice2"]
+
+    def synthesize(self, utterance: str, **kwargs) -> Tuple[str, Optional[str]]:
+        tmp = tempfile.NamedTemporaryFile(suffix=".wav", delete=False)
+        tmp.close()
+        with wave.open(tmp.name, "w") as wf:
+            wf.setnchannels(1)
+            wf.setsampwidth(2)
+            wf.setframerate(16000)
+            wf.writeframes(b"\x00\x00" * 1600)
+        return tmp.name, None
+
+
+def _free_port() -> int:
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def run_live_server(register):
+    """Yield a base URL for a uvicorn server that ran `register(app, engine)`.
+
+    `register` is a callable that takes (FastAPI app, FakeEngine) and mounts
+    the compat router under test.
+    """
+    import uvicorn
+    from fastapi import FastAPI
+
+    engine = FakeEngine()
+    app = FastAPI()
+    register(app, engine)
+
+    port = _free_port()
+    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="error")
+    server = uvicorn.Server(config)
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+
+    # Wait for startup (uvicorn sets .started after the lifespan handshake)
+    for _ in range(100):
+        if server.started:
+            break
+        time.sleep(0.05)
+    else:
+        raise RuntimeError("uvicorn live server failed to start")
+
+    base_url = f"http://127.0.0.1:{port}"
+    try:
+        yield base_url
+    finally:
+        server.should_exit = True
+        thread.join(timeout=5)

--- a/test/integration/test_elevenlabs_live.py
+++ b/test/integration/test_elevenlabs_live.py
@@ -1,0 +1,49 @@
+"""Live test: drive the /elevenlabs compat router with the official
+`elevenlabs` Python SDK pointed at a uvicorn server in this process.
+"""
+import pytest
+
+elevenlabs = pytest.importorskip("elevenlabs")
+
+from test.integration.conftest import run_live_server
+
+
+def _register(app, engine):
+    from ovos_tts_server.routers.elevenlabs import make_elevenlabs_router
+    app.include_router(make_elevenlabs_router(engine))
+
+
+@pytest.fixture(scope="module")
+def base_url():
+    yield from run_live_server(_register)
+
+
+@pytest.fixture(scope="module")
+def client(base_url):
+    from elevenlabs.client import ElevenLabs
+    return ElevenLabs(api_key="ignored", base_url=f"{base_url}/elevenlabs")
+
+
+class TestElevenLabsSDK:
+    def test_list_voices(self, client):
+        page = client.voices.get_all()
+        # SDK returns an object with a `.voices` attribute
+        voices = getattr(page, "voices", None) or page
+        assert len(voices) >= 1
+        first = voices[0]
+        # Either an object with .voice_id/.name or a dict
+        vid = getattr(first, "voice_id", None) or first["voice_id"]
+        name = getattr(first, "name", None) or first["name"]
+        assert vid
+        assert name
+
+    def test_text_to_speech_convert_returns_audio(self, client):
+        audio_chunks = client.text_to_speech.convert(
+            voice_id="default",
+            text="hello world",
+        )
+        # SDK returns an iterator of bytes
+        audio = b"".join(audio_chunks)
+        assert audio  # non-empty
+        # Without pydub, our server falls back to WAV bytes
+        assert audio.startswith(b"RIFF") or audio.startswith(b"ID3") or len(audio) > 16

--- a/test/unittests/test_compat_routers.py
+++ b/test/unittests/test_compat_routers.py
@@ -1,0 +1,131 @@
+# Licensed under the Apache License, Version 2.0
+"""Unit tests for TTS server compatibility routers.
+
+Uses a lightweight mock engine to avoid loading any OVOS TTS plugin.
+
+All compat routers are mounted under a named prefix (e.g. /elevenlabs, /openai)
+to avoid path conflicts when all routers are registered in the same FastAPI app.
+"""
+import base64
+import os
+import tempfile
+import wave
+from typing import List, Optional, Tuple
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+class FakeEngine:
+    """Mock TTSEngineWrapper for testing routers without a real plugin."""
+
+    plugin_name: str = "fake-tts"
+    lang: str = "en-us"
+    langs: List[str] = ["en-us", "de-de"]
+    voices: List[str] = ["voice1", "voice2"]
+
+    def synthesize(self, utterance: str, **kwargs) -> Tuple[str, Optional[str]]:
+        """Write a minimal WAV and return its path."""
+        tmp = tempfile.NamedTemporaryFile(suffix=".wav", delete=False)
+        tmp.close()
+        with wave.open(tmp.name, "w") as wf:
+            wf.setnchannels(1)
+            wf.setsampwidth(2)
+            wf.setframerate(16000)
+            wf.writeframes(b"\x00\x00" * 100)
+        return tmp.name, None
+
+
+@pytest.fixture(scope="module")
+def engine():
+    """Provide a shared FakeEngine instance."""
+    return FakeEngine()
+
+def _make_app(engine) -> FastAPI:
+    """Build a minimal FastAPI app with only the elevenlabs compat router."""
+    from ovos_tts_server.routers.elevenlabs import make_elevenlabs_router
+
+    app = FastAPI()
+    app.include_router(make_elevenlabs_router(engine))
+    return app
+
+
+@pytest.fixture(scope="module")
+def client(engine):
+    """Return a TestClient wired to the compat router app."""
+    app = _make_app(engine)
+    return TestClient(app)
+
+
+
+
+# ---------------------------------------------------------------------------
+# ElevenLabs  (prefix: /elevenlabs)
+# ---------------------------------------------------------------------------
+
+class TestElevenLabsRouter:
+    def test_list_voices_returns_voices(self, client):
+        resp = client.get("/elevenlabs/v1/voices")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "voices" in body
+        assert len(body["voices"]) >= 1
+        assert "voice_id" in body["voices"][0]
+        assert "name" in body["voices"][0]
+
+    def test_list_voices_api_key_ignored(self, client):
+        resp = client.get("/elevenlabs/v1/voices", headers={"xi-api-key": "fake-key"})
+        assert resp.status_code == 200
+
+    def test_list_models(self, client):
+        resp = client.get("/elevenlabs/v1/models")
+        assert resp.status_code == 200
+        models = resp.json()
+        assert isinstance(models, list)
+        assert len(models) >= 1
+        assert models[0]["model_id"] == "fake-tts"
+
+    def test_tts_default_voice(self, client):
+        resp = client.post(
+            "/elevenlabs/v1/text-to-speech/default",
+            json={"text": "hello world"},
+        )
+        assert resp.status_code == 200
+
+    def test_tts_named_voice(self, client):
+        resp = client.post(
+            "/elevenlabs/v1/text-to-speech/voice1",
+            json={"text": "test"},
+        )
+        assert resp.status_code == 200
+
+    def test_tts_output_format_mp3(self, client):
+        resp = client.post(
+            "/elevenlabs/v1/text-to-speech/default?output_format=mp3_44100_128",
+            json={"text": "test"},
+        )
+        assert resp.status_code == 200
+
+    def test_tts_empty_text_rejected(self, client):
+        resp = client.post(
+            "/elevenlabs/v1/text-to-speech/default",
+            json={"text": ""},
+        )
+        assert resp.status_code == 422
+
+    def test_tts_voice_settings_accepted(self, client):
+        resp = client.post(
+            "/elevenlabs/v1/text-to-speech/default",
+            json={"text": "hello", "voice_settings": {"stability": 0.5, "similarity_boost": 0.8}},
+        )
+        assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# OpenAI TTS  (prefix: /openai)
+# ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Standalone slice extracted from #84. Adds a **elevenlabs**-compatible TTS API at `/elevenlabs` so apps already speaking the elevenlabs HTTP API can swap in OVOS with no client changes.

### Upstream API

Implements [ElevenLabs Text-to-Speech API](https://elevenlabs.io/docs/api-reference/text-to-speech) — endpoints: `GET /v1/voices`, `POST /v1/text-to-speech/{voice_id}`, `GET /v1/models`.

Auth tokens / API keys are accepted on every endpoint and silently ignored — wrap behind a reverse proxy if you need real auth.

### What this PR adds

- New router file in `ovos_tts_server/routers/` exposing a `make_*_router(engine)` factory
- Registered in `create_app()` (`ovos_tts_server/__init__.py`)
- Unit tests in `test/unittests/test_compat_routers.py`
- Vendor section in `docs/api-compatibility.md`

### Foundation

Built on the merged foundation PR #86 (`audio_utils`, routers/ package, `[audio]` extra, CORS, `/status`). Each compat PR is independently mergeable in any order.

### Replaces

Supersedes part of the original monolithic PR #84.

### Test plan

- [ ] `pip install -e .[audio,test]`
- [ ] `pytest test/unittests/test_compat_routers.py -v`
- [ ] Manual smoke: hit a `/elevenlabs` endpoint against a running server
