### PR TITLE
docs: voice-pihole hub — /docs index + centralised nginx recipes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,93 @@
+# `ovos-tts-server` Documentation Hub
+
+`ovos-tts-server` exposes any OVOS TTS plugin as a network service. On its
+own it speaks one native protocol — but with compat routers enabled it
+also pretends to be every major cloud TTS API and every popular
+self-hosted server, so **unmodified consumer apps transparently land on
+this box** instead of a third-party cloud.
+
+| Goal | Read |
+| :--- | :--- |
+| Make unmodified consumer apps stop calling cloud TTS services | [voice-pihole.md](voice-pihole.md) |
+| Drive this server with the official Python/Node SDK of a specific vendor | [api-compatibility.md](api-compatibility.md) |
+| Replace an existing self-hosted TTS server on the wire | [api-compatibility.md](api-compatibility.md) |
+| Bridge Home Assistant Voice / Voice PE | [wyoming-integration.md](wyoming-integration.md) |
+| Audio format negotiation | [audio-formats.md](audio-formats.md) |
+| Voice + language plumbing | [configuration.md](configuration.md) |
+| Native `/v2/synthesize` endpoint | [index.md](index.md) |
+
+## Compat coverage matrix
+
+- ✅ **merged** — landed on `dev`; per-vendor docs inlined in [`api-compatibility.md`](api-compatibility.md).
+- 🟡 **open** — PR up; per-vendor docs on the feature branch.
+- ⚪ **planned** — see [TODO / WIP](#todo--wip).
+
+### Commercial cloud TTS
+
+| Vendor | Prefix | Status | PR |
+| :--- | :--- | :--- | :--- |
+| ElevenLabs | `/elevenlabs` | 🟡 open | [#87](https://github.com/OpenVoiceOS/ovos-tts-server/pull/87) |
+| OpenAI TTS | `/openai` | 🟡 open | [#88](https://github.com/OpenVoiceOS/ovos-tts-server/pull/88) |
+| Google Cloud TTS | `/google-tts` | 🟡 open | [#90](https://github.com/OpenVoiceOS/ovos-tts-server/pull/90) |
+| Amazon Polly | `/amazon-polly` | 🟡 open | [#91](https://github.com/OpenVoiceOS/ovos-tts-server/pull/91) |
+| Microsoft Azure Speech | `/azure-tts` (REST + WS) | 🟡 open | [#92](https://github.com/OpenVoiceOS/ovos-tts-server/pull/92) |
+
+### Self-hosted / open-source TTS server protocols
+
+| Server | Prefix | Status | PR |
+| :--- | :--- | :--- | :--- |
+| Coqui TTS server | `/coqui` | 🟡 open | [#89](https://github.com/OpenVoiceOS/ovos-tts-server/pull/89) |
+| Piper HTTP server | `/piper` | 🟡 open | [#93](https://github.com/OpenVoiceOS/ovos-tts-server/pull/93) |
+| MaryTTS | `/marytts` + root aliases | 🟡 open | [#94](https://github.com/OpenVoiceOS/ovos-tts-server/pull/94) |
+
+> :information_source: Status reflects merge-into-`dev`. Until a PR lands,
+> its per-vendor docs section lives on the feature branch — click the PR
+> link.
+
+## Voice-pihole
+
+[voice-pihole.md](voice-pihole.md) collects every DNS-rewrite + reverse-proxy
++ CA-trust recipe across all the above vendors. Use it when you want
+unmodified consumer apps to transparently hit this server with zero
+client-side configuration.
+
+---
+
+## TODO / WIP
+
+### Streaming partial audio
+
+The OpenAI/ElevenLabs/Azure SDKs all support streaming synthesis (audio
+chunks delivered as the model generates them). Our compat routers
+currently emit the entire WAV body in one response after the OVOS plugin
+finishes — which is what OVOS TTS plugins natively produce. True chunked
+streaming would need either:
+
+- A streaming-aware plugin contract (OPM change), OR
+- Server-side chunking of the produced WAV (latency only, no first-byte
+  win)
+
+### Vendor coverage gaps
+
+- **Cartesia / PlayHT / Resemble / Murf** — emerging neural-TTS APIs.
+- **Microsoft Speech SDK WebSocket synthesis** — implemented (PR #92),
+  but the `output_format` enum doesn't cover every Microsoft profile.
+- **Mimic 3 / Mycroft Mimic server** — historical OVOS-adjacent
+  protocols; useful for self-hoster migration paths.
+- **Festival / espeak-ng HTTP wrappers** — niche, mostly accessibility.
+
+### Documentation TODOs
+
+- One-pager per use-case (Raspberry Pi, Tailscale, Caddy alternative).
+- mkcert / step-ca walkthrough.
+- Per-vendor migration guide (SDK → drop-in mode).
+- Native `/v2/synthesize` deep-dive: streaming responses, cache busting,
+  voice listing.
+
+### Process
+
+Each open compat PR rebases on `dev` after this hub merges and in its
+diff:
+
+1. Removes its row's PR link from the index in `api-compatibility.md`.
+2. Inlines its full per-vendor docs section below the index.

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,9 +18,9 @@ this box** instead of a third-party cloud.
 
 ## Compat coverage matrix
 
-- ✅ **merged** — landed on `dev`; per-vendor docs inlined in [`api-compatibility.md`](api-compatibility.md).
-- 🟡 **open** — PR up; per-vendor docs on the feature branch.
-- ⚪ **planned** — see [TODO / WIP](#todo--wip).
+- ✅ **merged** — landed on `dev`
+- 🟡 **open** — PR up
+- ⚪ **planned**
 
 ### Commercial cloud TTS
 
@@ -40,54 +40,35 @@ this box** instead of a third-party cloud.
 | Piper HTTP server | `/piper` | 🟡 open | [#93](https://github.com/OpenVoiceOS/ovos-tts-server/pull/93) |
 | MaryTTS | `/marytts` + root aliases | 🟡 open | [#94](https://github.com/OpenVoiceOS/ovos-tts-server/pull/94) |
 
-> :information_source: Status reflects merge-into-`dev`. Until a PR lands,
-> its per-vendor docs section lives on the feature branch — click the PR
-> link.
-
 ## Voice-pihole
 
 [voice-pihole.md](voice-pihole.md) collects every DNS-rewrite + reverse-proxy
-+ CA-trust recipe across all the above vendors. Use it when you want
-unmodified consumer apps to transparently hit this server with zero
-client-side configuration.
++ CA-trust recipe across all the above vendors.
 
 ---
 
-## TODO / WIP
+## TODO
 
 ### Streaming partial audio
 
-The OpenAI/ElevenLabs/Azure SDKs all support streaming synthesis (audio
-chunks delivered as the model generates them). Our compat routers
-currently emit the entire WAV body in one response after the OVOS plugin
-finishes — which is what OVOS TTS plugins natively produce. True chunked
-streaming would need either:
-
-- A streaming-aware plugin contract (OPM change), OR
-- Server-side chunking of the produced WAV (latency only, no first-byte
-  win)
+The OpenAI / ElevenLabs / Azure SDKs all support streaming synthesis
+(audio chunks delivered as the model generates them). Our compat routers
+emit the entire WAV body in one response after the OVOS plugin finishes
+— which is what OVOS TTS plugins natively produce. True chunked
+streaming needs either a streaming-aware plugin contract (OPM change) or
+server-side chunking of the produced WAV.
 
 ### Vendor coverage gaps
 
-- **Cartesia / PlayHT / Resemble / Murf** — emerging neural-TTS APIs.
-- **Microsoft Speech SDK WebSocket synthesis** — implemented (PR #92),
-  but the `output_format` enum doesn't cover every Microsoft profile.
-- **Mimic 3 / Mycroft Mimic server** — historical OVOS-adjacent
-  protocols; useful for self-hoster migration paths.
-- **Festival / espeak-ng HTTP wrappers** — niche, mostly accessibility.
+- Cartesia / PlayHT / Resemble / Murf — emerging neural-TTS APIs.
+- Microsoft Speech SDK WS — the `output_format` enum doesn't cover every
+  Microsoft profile.
+- Mimic 3 / Mycroft Mimic server.
+- Festival / espeak-ng HTTP wrappers.
 
-### Documentation TODOs
+### Docs
 
-- One-pager per use-case (Raspberry Pi, Tailscale, Caddy alternative).
+- One-pager per deployment (Raspberry Pi, Tailscale, Caddy alternative).
 - mkcert / step-ca walkthrough.
-- Per-vendor migration guide (SDK → drop-in mode).
-- Native `/v2/synthesize` deep-dive: streaming responses, cache busting,
-  voice listing.
-
-### Process
-
-Each open compat PR rebases on `dev` after this hub merges and in its
-diff:
-
-1. Removes its row's PR link from the index in `api-compatibility.md`.
-2. Inlines its full per-vendor docs section below the index.
+- Per-vendor migration guide (SDK → drop-in).
+- Native `/v2/synthesize` deep-dive.

--- a/docs/api-compatibility.md
+++ b/docs/api-compatibility.md
@@ -1,9 +1,42 @@
 # Third-Party API Compatibility
 
-`ovos-tts-server` can expose its underlying OVOS TTS plugin behind drop-in compatibility endpoints for popular cloud TTS APIs. This lets existing apps that already speak a vendor's HTTP API use OVOS as a drop-in replacement — no client code changes required.
+`ovos-tts-server` exposes its underlying OVOS TTS plugin behind drop-in
+compatibility endpoints for popular cloud TTS APIs. Each vendor lives
+under its own URL prefix so multiple compat layers coexist with no path
+collisions.
 
-Each vendor's endpoints live under a dedicated URL prefix so multiple compat layers can coexist in one FastAPI app with no path collisions. Concrete vendor sections (request schema, query params, response shape, curl examples) are added by each compat-router PR as it lands.
+All routers accept any auth token / API key supplied by the client and
+silently ignore it — authentication is the responsibility of your
+reverse proxy.
 
-All routers accept any auth token / API key supplied by the client and silently ignore it — authentication is the responsibility of your reverse proxy.
+Audio format conversion across `wav`, `mp3`, `ogg`, `flac`, `pcm`, etc.
+is provided by `ovos_tts_server.audio_utils.convert_audio()`. Install
+the `[audio]` extra (`pip install ovos-tts-server[audio]`) to enable
+non-WAV outputs via `pydub`.
 
-Audio format conversion across `wav`, `mp3`, `ogg`, `flac`, `pcm`, etc. is provided by `ovos_tts_server.audio_utils.convert_audio()`. Install the `[audio]` extra (`pip install ovos-tts-server[audio]`) to enable non-WAV outputs via `pydub`.
+The shared network-redirect concept lives in
+[`voice-pihole.md`](voice-pihole.md); per-vendor sections cross-reference
+it.
+
+Status reflects merge state into `dev`:
+
+- ✅ **merged** — full per-vendor docs section below the index.
+- 🟡 **open** — PR is up; full docs on the feature branch.
+
+## Commercial cloud TTS
+
+| Vendor | Prefix | Status | PR |
+| :--- | :--- | :--- | :--- |
+| ElevenLabs | `/elevenlabs` | 🟡 open | [#87](https://github.com/OpenVoiceOS/ovos-tts-server/pull/87) |
+| OpenAI TTS | `/openai` | 🟡 open | [#88](https://github.com/OpenVoiceOS/ovos-tts-server/pull/88) |
+| Google Cloud TTS | `/google-tts` | 🟡 open | [#90](https://github.com/OpenVoiceOS/ovos-tts-server/pull/90) |
+| Amazon Polly | `/amazon-polly` | 🟡 open | [#91](https://github.com/OpenVoiceOS/ovos-tts-server/pull/91) |
+| Microsoft Azure TTS | `/azure-tts` (REST + WS) | 🟡 open | [#92](https://github.com/OpenVoiceOS/ovos-tts-server/pull/92) |
+
+## Self-hosted / OSS server protocols
+
+| Server | Prefix | Status | PR |
+| :--- | :--- | :--- | :--- |
+| Coqui TTS server | `/coqui` | 🟡 open | [#89](https://github.com/OpenVoiceOS/ovos-tts-server/pull/89) |
+| Piper HTTP server | `/piper` | 🟡 open | [#93](https://github.com/OpenVoiceOS/ovos-tts-server/pull/93) |
+| MaryTTS | `/marytts` + root aliases | 🟡 open | [#94](https://github.com/OpenVoiceOS/ovos-tts-server/pull/94) |

--- a/docs/api-compatibility.md
+++ b/docs/api-compatibility.md
@@ -15,13 +15,10 @@ the `[audio]` extra (`pip install ovos-tts-server[audio]`) to enable
 non-WAV outputs via `pydub`.
 
 The shared network-redirect concept lives in
-[`voice-pihole.md`](voice-pihole.md); per-vendor sections cross-reference
-it.
+[`voice-pihole.md`](voice-pihole.md).
 
-Status reflects merge state into `dev`:
-
-- ✅ **merged** — full per-vendor docs section below the index.
-- 🟡 **open** — PR is up; full docs on the feature branch.
+- ✅ **merged** — landed on `dev`
+- 🟡 **open** — PR up
 
 ## Commercial cloud TTS
 

--- a/docs/voice-pihole.md
+++ b/docs/voice-pihole.md
@@ -1,0 +1,298 @@
+# Voice Pihole (TTS)
+
+A single network-layer interception recipe per cloud TTS vendor so that
+**unmodified consumer apps stop calling cloud services** and land on your
+`ovos-tts-server` box instead. No client SDK changes, no API key swaps,
+no app-config edits — just DNS + a TLS-terminating reverse proxy.
+
+The pattern across every vendor is the same:
+
+1. **DNS interception.** Pin the vendor's hostname to your server's IP
+   via `/etc/hosts` (single host) or your LAN's DNS (Pi-hole / Unbound /
+   dnsmasq / pfSense / OPNsense).
+2. **TLS termination.** Run nginx (or Caddy / HAProxy / Envoy) on `443`
+   for the vendor's hostname, holding a cert your clients trust.
+3. **Path rewrite.** Map the vendor's upstream path to our internal
+   prefix so the rest of FastAPI's routing works.
+4. **CA trust.** Either sign the proxy cert with a CA the client already
+   trusts (corporate PKI, mkcert root) or push the CA into the client's
+   trust store (`REQUESTS_CA_BUNDLE`, `SSL_CERT_FILE`, system trust).
+
+This document holds the consolidated config. Each per-vendor section in
+[`api-compatibility.md`](api-compatibility.md) cross-references it.
+
+> :warning: **Intercepting a hostname catches *every* request to it.** If
+> the vendor host is shared with other features (e.g. OpenAI chat on
+> `api.openai.com`), the nginx block must forward unrelated paths back to
+> the upstream or 404 them explicitly. The examples below do this.
+
+---
+
+## Common nginx prelude
+
+Every server block below assumes this `map` directive is in your
+`nginx.conf` (or in a `conf.d/*.conf` snippet loaded into `http {}`):
+
+```nginx
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+```
+
+It's needed any time a WS upgrade is forwarded.
+
+---
+
+## Cert + CA trust setup
+
+For each hostname you intercept you need an X.509 cert with the vendor's
+hostname in the SAN list. Two common approaches:
+
+### A) Internal CA (production)
+
+1. Generate an internal CA (e.g. via `step-ca`, `cfssl`, or `openssl`).
+2. Install the CA cert in the client device's trust store (corporate
+   MDM, dotfiles, system keychain, `update-ca-certificates`).
+3. Issue per-hostname leaf certs from this CA.
+
+### B) mkcert (lab / dev)
+
+```bash
+brew install mkcert  # or apt / scoop / cargo
+mkcert -install
+mkcert api.elevenlabs.io api.openai.com '*.googleapis.com' \
+       polly.us-east-1.amazonaws.com \
+       '*.tts.speech.microsoft.com'
+```
+
+mkcert installs its CA into the system trust automatically.
+
+---
+
+## Per-vendor nginx blocks
+
+### ElevenLabs (`api.elevenlabs.io`)
+
+```nginx
+server {
+    listen 443 ssl;
+    server_name api.elevenlabs.io;
+    ssl_certificate     /etc/ssl/private/api.elevenlabs.io.crt;
+    ssl_certificate_key /etc/ssl/private/api.elevenlabs.io.key;
+
+    location /v1/text-to-speech/ {
+        proxy_pass         http://127.0.0.1:9666/elevenlabs/v1/text-to-speech/;
+        proxy_set_header   Host $host;
+        proxy_buffering    off;
+    }
+    location /v1/voices {
+        proxy_pass         http://127.0.0.1:9666/elevenlabs/v1/voices;
+        proxy_set_header   Host $host;
+    }
+    location / { return 404; }
+}
+```
+
+### OpenAI TTS (`api.openai.com`)
+
+```nginx
+server {
+    listen 443 ssl;
+    server_name api.openai.com;
+    ssl_certificate     /etc/ssl/private/api.openai.com.crt;
+    ssl_certificate_key /etc/ssl/private/api.openai.com.key;
+
+    # Audio endpoints → /openai/v1/audio/*
+    location /v1/audio/speech {
+        proxy_pass         http://127.0.0.1:9666/openai/v1/audio/speech;
+        proxy_set_header   Host $host;
+        proxy_buffering    off;
+    }
+    # Apps often probe /v1/models at startup; benign stub
+    location /v1/models {
+        return 200 '{"data":[]}';
+        add_header Content-Type application/json;
+    }
+    location / { return 404; }
+}
+```
+
+### Google Cloud TTS (`texttospeech.googleapis.com`)
+
+```nginx
+server {
+    listen 443 ssl;
+    server_name texttospeech.googleapis.com;
+    ssl_certificate     /etc/ssl/private/texttospeech.googleapis.com.crt;
+    ssl_certificate_key /etc/ssl/private/texttospeech.googleapis.com.key;
+
+    location /v1/text:synthesize {
+        proxy_pass         http://127.0.0.1:9666/google-tts/v1/text:synthesize;
+        proxy_set_header   Host $host;
+        proxy_buffering    off;
+    }
+    location /v1/voices {
+        proxy_pass         http://127.0.0.1:9666/google-tts/v1/voices;
+        proxy_set_header   Host $host;
+    }
+    location / { return 404; }
+}
+```
+
+### Amazon Polly (`polly.<region>.amazonaws.com`)
+
+```nginx
+server {
+    listen 443 ssl;
+    server_name ~^polly\.[a-z0-9-]+\.amazonaws\.com$;
+    ssl_certificate     /etc/ssl/private/polly.amazonaws.com.crt;
+    ssl_certificate_key /etc/ssl/private/polly.amazonaws.com.key;
+
+    location /v1/speech {
+        proxy_pass         http://127.0.0.1:9666/amazon-polly/v1/speech;
+        proxy_set_header   Host $host;
+        proxy_buffering    off;
+    }
+    location /v1/voices {
+        proxy_pass         http://127.0.0.1:9666/amazon-polly/v1/voices;
+        proxy_set_header   Host $host;
+    }
+    location / { return 404; }
+}
+```
+
+### Microsoft Azure TTS (`<region>.tts.speech.microsoft.com`, REST + WS)
+
+```nginx
+server {
+    listen 443 ssl;
+    server_name ~^[a-z0-9]+\.tts\.speech\.microsoft\.com$;
+    ssl_certificate     /etc/ssl/private/tts.speech.microsoft.com.crt;
+    ssl_certificate_key /etc/ssl/private/tts.speech.microsoft.com.key;
+
+    # REST synth
+    location /cognitiveservices/v1 {
+        proxy_pass         http://127.0.0.1:9666/azure-tts/cognitiveservices/v1;
+        proxy_set_header   Host $host;
+        proxy_buffering    off;
+    }
+    # WebSocket synth (Microsoft proprietary framing)
+    location /cognitiveservices/websocket/v1 {
+        proxy_pass         http://127.0.0.1:9666/azure-tts/cognitiveservices/websocket/v1;
+        proxy_http_version 1.1;
+        proxy_set_header   Upgrade $http_upgrade;
+        proxy_set_header   Connection $connection_upgrade;
+        proxy_set_header   Host $host;
+        proxy_read_timeout 300s;
+        proxy_buffering    off;
+    }
+    # Voices list
+    location /cognitiveservices/voices/list {
+        proxy_pass         http://127.0.0.1:9666/azure-tts/cognitiveservices/voices/list;
+        proxy_set_header   Host $host;
+    }
+    location / { return 404; }
+}
+```
+
+---
+
+## Self-hosted TTS server replacement
+
+For self-hosted protocols (Coqui, Piper, MaryTTS) the canonical move is
+to **replace the running server on the same bind port**. Stop the old
+process, start `ovos-tts-server` on the same port, clients keep working.
+
+### Coqui TTS server (`coqui-ai/TTS` reference)
+
+Coqui's bundled HTTP server defaults to `http://localhost:5002/api/tts`.
+Run `ovos-tts-server --port 5002` and apps drop in unchanged. If you
+prefer a separate port, add nginx:
+
+```nginx
+server {
+    listen 5002;
+    server_name _;
+
+    location /api/tts {
+        proxy_pass         http://127.0.0.1:9666/coqui/api/tts;
+        proxy_set_header   Host $host;
+        proxy_buffering    off;
+    }
+}
+```
+
+### Piper HTTP server
+
+Piper's HTTP server typically binds on `5000` or `8000`. Same pattern —
+replace the bind port or add a path-preserving nginx:
+
+```nginx
+server {
+    listen 5000;
+    server_name _;
+
+    location / {
+        proxy_pass         http://127.0.0.1:9666/piper/;
+        proxy_set_header   Host $host;
+        proxy_buffering    off;
+    }
+}
+```
+
+### MaryTTS
+
+MaryTTS clients typically post to `http://marytts:59125/process`. Our
+`/marytts` router also exposes root aliases (`/process`, `/voices`,
+`/version`) so legacy clients with hardcoded bare paths work. The DNS
+move alone is enough:
+
+```text
+# /etc/hosts on the client (or LAN DNS)
+192.168.1.50    marytts
+```
+
+If MaryTTS clients hit a hostname directly:
+
+```nginx
+server {
+    listen 59125;
+    server_name marytts;
+
+    location / {
+        proxy_pass         http://127.0.0.1:9666/marytts/;
+        proxy_set_header   Host $host;
+        proxy_buffering    off;
+    }
+}
+```
+
+---
+
+## Putting it together
+
+A complete "voice pihole" deployment is:
+
+```
+┌──────────────────────────────┐
+│   Pi-hole / Unbound / pfSense│   1) DNS rewrites for all the hosts above
+│   (LAN-wide DNS)             │
+└──────────────┬───────────────┘
+               │ resolves api.openai.com etc. → 192.168.1.50
+               ▼
+┌──────────────────────────────┐
+│   nginx (192.168.1.50:443)   │   2) TLS termination + path rewrite
+│   - one server{} per vendor  │   3) cert from a CA trusted on clients
+└──────────────┬───────────────┘
+               │ proxies to 127.0.0.1:9666/<vendor-prefix>/...
+               ▼
+┌──────────────────────────────┐
+│   ovos-tts-server            │   4) compat router for each vendor
+│   :9666 (HTTP)               │      → OVOS TTS plugin (the actual synth)
+└──────────────────────────────┘
+```
+
+Once the DNS rewrite + TLS cert + reverse proxy are in place, **every**
+consumer app on the LAN that uses any of the above APIs is automatically
+served by your local OVOS TTS plugin — no client-side change required.

--- a/docs/wyoming-integration.md
+++ b/docs/wyoming-integration.md
@@ -1,0 +1,57 @@
+# Wyoming integration (TTS)
+
+The [Wyoming protocol](https://github.com/rhasspy/wyoming) is Home Assistant's
+length-prefixed JSONL framing for STT / TTS / wake-word over raw TCP. It is
+**not** an HTTP API and is **not** implemented as a router in this server.
+
+## Why not native?
+
+- Wyoming uses raw TCP framing on port 10200 (TTS) / 10300 (STT), not
+  HTTP — it does not fit the FastAPI router model the rest of
+  `ovos-tts-server` uses.
+- Dedicated bridge servers already exist and are kept in sync with
+  upstream Wyoming (which evolves independently of our HTTP compat layer).
+
+## Use the adapter repo
+
+The OVOS-side bridge speaks Wyoming on its native TCP port and forwards
+to a backend service — point it at this server's `/v2/synthesize`
+endpoint and Home Assistant Voice / Voice PE picks it up transparently.
+
+| Adapter | Repo | Backend it bridges |
+| :--- | :--- | :--- |
+| Wyoming TTS  | [TigreGotico/wyoming-ovos-tts](https://github.com/TigreGotico/wyoming-ovos-tts) | Any OVOS TTS plugin, or **this server's** `/v2/synthesize` endpoint |
+
+The STT and wake-word counterparts live in:
+- [TigreGotico/wyoming-ovos-stt](https://github.com/TigreGotico/wyoming-ovos-stt)
+- [TigreGotico/wyoming-ovos-wakeword](https://github.com/TigreGotico/wyoming-ovos-wakeword)
+
+## Typical deployment
+
+```text
+  ┌─────────────────────────┐         ┌──────────────────────────┐
+  │  Home Assistant Voice   │  TCP    │  wyoming-ovos-tts        │
+  │  (wyoming client)       ├────────►│  (port 10200)            │
+  └─────────────────────────┘         └────────────┬─────────────┘
+                                                   │ HTTP
+                                                   ▼
+                                       ┌──────────────────────────┐
+                                       │  ovos-tts-server         │
+                                       │  /v2/synthesize          │
+                                       │  (port 9666)             │
+                                       └──────────────────────────┘
+```
+
+Run both on the same box (or split them across hosts):
+
+```bash
+# 1. The TTS engine
+ovos-tts-server --engine ovos-tts-plugin-piper --port 9666
+
+# 2. The Wyoming bridge — point it at our HTTP endpoint
+wyoming-ovos-tts --uri tcp://0.0.0.0:10200 --tts-url http://localhost:9666
+```
+
+Configure HA's Wyoming integration with `tcp://<host>:10200` and the
+voice pipeline picks up a normal Wyoming TTS service — no special-casing
+for OVOS.


### PR DESCRIPTION
## Summary

Docs-only PR that introduces the documentation hub for all 8 open TTS compat routers and consolidates the network-redirect ("voice pihole") nginx config into a single source of truth — same treatment as [`ovos-stt-http-server#70`](https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/70).

### Files

- \`docs/README.md\` — top-level index with the compat coverage matrix listing every compat surface (5 commercial + 3 self-hosted) with its URL prefix and shipping status; plus a TODO/WIP section.
- \`docs/voice-pihole.md\` — **the** voice-pihole guide. One nginx \`server{}\` per vendor host (\`api.elevenlabs.io\`, \`api.openai.com\`, \`texttospeech.googleapis.com\`, \`polly.<region>.amazonaws.com\`, \`<region>.tts.speech.microsoft.com\`) + port-swap recipes for self-hosted Coqui/Piper/MaryTTS. Common nginx prelude + CA-trust section + topology diagram.
- \`docs/wyoming-integration.md\` — points HA Voice users at \`TigreGotico/wyoming-ovos-tts\`.
- \`docs/api-compatibility.md\` — master-index placeholder with one row per in-flight compat PR.

### Merge plan

1. **This PR merges first.** No code changes; only docs.
2. Each open compat PR (#87–#94) rebases on \`dev\`, replaces its row in \`docs/api-compatibility.md\` with the full per-vendor section, and adds an \`examples/<vendor>_example.py\` (follow-up PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)