### PR TITLE
test: run the official-SDK e2e tests in CI (add vendor SDKs to test extra)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
 
 [project.optional-dependencies]
 audio = ["pydub"]
-test = ["pytest", "httpx"]
+test = ["pytest", "httpx", "requests", "openai", "boto3", "elevenlabs", "google-cloud-texttospeech", "azure-cognitiveservices-speech", "ovos-tts-plugin-polly"]
 
 [project.urls]
 Homepage = "https://github.com/OpenVoiceOS/ovos-tts-server"


### PR DESCRIPTION
The TTS compat routers ship **official-SDK e2e tests** (elevenlabs, openai, google-cloud-texttospeech, boto3, azure-cognitiveservices-speech, ovos-tts-plugin-polly), but the test extra was only `[pytest, httpx]` — so every SDK e2e test **skipped in CI**. The routers were never actually e2e-verified, and coverage sat at 88%.

Adding the SDKs makes the e2e tests **run for real**: 28 integration tests pass, and total coverage rises to **93%**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)