### PR TITLE
docs: modernize README and full /docs reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,60 @@
 # OpenVoiceOS TTS Server
 
-Turn any OVOS TTS plugin into a microservice — a small, stateless FastAPI app that exposes a TTS plugin over HTTP.
+[![PyPI](https://img.shields.io/pypi/v/ovos-tts-server)](https://pypi.org/project/ovos-tts-server/)
+[![Python](https://img.shields.io/pypi/pyversions/ovos-tts-server)](https://pypi.org/project/ovos-tts-server/)
+[![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE.md)
+
+Turn **any** [OVOS TTS plugin](https://github.com/OpenVoiceOS) into a microservice — a small, stateless [FastAPI](https://fastapi.tiangolo.com/) app that exposes text-to-speech over HTTP.
+
+- 🔌 **Plugin-agnostic** — serve Piper, Coqui, Azure, or any OVOS TTS plugin behind one consistent HTTP API.
+- 🧩 **Drop-in cloud-API compatibility** — speak the ElevenLabs, OpenAI, Coqui, Google, Amazon Polly, and Azure APIs so existing clients and SDKs work unmodified (see [API compatibility](docs/api-compatibility.md)).
+- 🪶 **Stateless & tiny** — each request loads nothing extra; ideal for containers and horizontal scaling.
+- 🎛️ **Format conversion** — return WAV out of the box, or mp3/ogg/flac/… with the optional `[audio]` extra.
+
+---
 
 ## Install
 
 ```bash
 pip install ovos-tts-server
 
-# Optional: enable non-WAV output (mp3, ogg, flac, ...) via pydub
+# Optional: enable non-WAV output (mp3, ogg, flac, …) via pydub
 pip install "ovos-tts-server[audio]"
 ```
 
-## Companion plugin
+You also need at least one TTS plugin, e.g. [Piper](https://github.com/OpenVoiceOS/ovos-tts-plugin-piper):
 
-Use in your voice assistant via the [companion TTS plugin](https://github.com/OpenVoiceOS/ovos-tts-server-plugin).
+```bash
+pip install ovos-tts-plugin-piper
+```
+
+## Quickstart
+
+```bash
+# Start the server with the Piper plugin
+ovos-tts-server --engine ovos-tts-plugin-piper
+
+# Synthesize over HTTP
+curl "http://localhost:9666/v2/synthesize?utterance=hello%20world" -o hello.wav
+```
+
+## Command line
+
+```
+ovos-tts-server [-h] [--engine ENGINE] [--port PORT] [--host HOST] [--cache] [--lang LANG]
+```
+
+| Option | Default | Description |
+| :--- | :--- | :--- |
+| `--engine ENGINE` | — | TTS plugin to load (e.g. `ovos-tts-plugin-piper`) |
+| `--port PORT` | `9666` | Port to bind |
+| `--host HOST` | `0.0.0.0` | Host/interface to bind |
+| `--cache` | off | Persist every synth to disk (cache across requests) |
+| `--lang LANG` | `en-us` | Default language reported by the plugin |
 
 ## Configuration
 
-The plugin is configured the same way as if it were running inside the assistant — through `mycroft.conf`:
+The plugin is configured exactly as it would be inside the assistant — through `mycroft.conf`:
 
 ```json
 {
@@ -30,49 +67,52 @@ The plugin is configured the same way as if it were running inside the assistant
 }
 ```
 
-## Usage
+See [docs/configuration.md](docs/configuration.md) for how voice and language flow from a request to the plugin.
 
-```bash
-ovos-tts-server --help
-usage: ovos-tts-server [-h] [--engine ENGINE] [--port PORT] [--host HOST] [--cache]
+## HTTP API
 
-options:
-  -h, --help       show this help message and exit
-  --engine ENGINE  tts plugin to be used
-  --port PORT      port number (default: 9666)
-  --host HOST      host (default: 0.0.0.0)
-  --cache          save every synth to disk
-```
-
-Example — serve the [Piper plugin](https://github.com/OpenVoiceOS/ovos-tts-plugin-piper):
-
-```bash
-ovos-tts-server --engine ovos-tts-plugin-piper --cache
-```
-
-Then GET `http://localhost:9666/synthesize/hello`.
-
-## Endpoints
+The native OVOS endpoints:
 
 | Method | Path | Description |
 | :--- | :--- | :--- |
 | GET | `/status` | Plugin name, supported languages, default voice/model |
-| GET | `/v2/synthesize?utterance=<text>[&lang=...][&voice=...]` | Primary synthesis endpoint — returns WAV audio |
+| GET | `/v2/synthesize?utterance=<text>[&lang=…][&voice=…]` | Primary synthesis endpoint — returns a WAV file |
 | GET | `/synthesize/<utterance>` | Legacy path-based synthesis endpoint |
 
-CORS is enabled for all origins.
+Any extra query parameters on the synthesis endpoints are forwarded to the plugin as synthesis options. CORS is enabled for all origins.
+
+```bash
+curl http://localhost:9666/status
+# {"status": "ok", "plugin": "ovos-tts-plugin-piper", "langs": ["en-us"], ...}
+```
 
 ### Third-party API compatibility
 
-The server can additionally expose its underlying TTS plugin behind drop-in compatibility endpoints for popular cloud TTS APIs — MaryTTS, ElevenLabs, OpenAI, Coqui, Google Cloud TTS, Amazon Polly, Azure, and Piper. Each vendor lives under its own URL prefix so multiple compat layers coexist with no path collisions. Auth tokens are accepted and silently ignored — wrap behind a reverse proxy if you need real auth.
+The server can **additionally** expose the same plugin behind drop-in compatibility endpoints for popular cloud TTS APIs. Each vendor lives under its own URL prefix, so every compat layer is active at once with no path collisions. Auth tokens / API keys are accepted and silently ignored — put real auth in a reverse proxy if you need it.
 
-See [docs/api-compatibility.md](docs/api-compatibility.md) for the full reference.
+| Vendor | Prefix | Key endpoint |
+| :--- | :--- | :--- |
+| ElevenLabs | `/elevenlabs` | `POST /v1/text-to-speech/{voice_id}` |
+| OpenAI | `/openai` | `POST /v1/audio/speech` |
+| Coqui | `/coqui` | `GET /api/tts` |
+| Google Cloud TTS | `/google-tts` | `POST /v1/text:synthesize` |
+| Amazon Polly | `/amazon-polly` | `POST /v1/speech` |
+| Azure TTS | `/azure-tts` | `POST /cognitiveservices/v1` |
 
-## Documentation
+> **Kokoro / kokoro-fastapi** clients are OpenAI-compatible and need no dedicated prefix — point them at `/openai/v1/audio/speech`.
 
-- [Configuration & voice/language flow](docs/configuration.md)
-- [Audio format conversion](docs/audio-formats.md)
-- [API compatibility reference](docs/api-compatibility.md)
+Most official SDKs accept a custom base URL; point them at `http://<host>:9666/<prefix>` and they work unmodified. See **[docs/api-compatibility.md](docs/api-compatibility.md)** for per-vendor endpoints, parameters, SDK snippets, and curl examples.
+
+## Python API
+
+```python
+from ovos_tts_server import start_tts_server
+
+app, engine = start_tts_server("ovos-tts-plugin-piper", cache=False)
+# `app` is a FastAPI instance — mount it, test it, or run it with uvicorn
+```
+
+`create_app(tts_engine)` is also available if you want to build and inject the `TTSEngineWrapper` yourself.
 
 ## Docker
 
@@ -89,11 +129,14 @@ ENTRYPOINT ["ovos-tts-server", "--engine", "{PLUGIN_HERE}", "--cache"]
 ```bash
 docker build . -t my_ovos_tts_plugin
 docker run -p 8080:9666 my_ovos_tts_plugin
+curl "http://localhost:8080/v2/synthesize?utterance=hello" -o hello.wav
 ```
 
-Then GET `http://localhost:8080/synthesize/hello`.
-
 Each plugin can ship its own Dockerfile in its repository using `ovos-tts-server`.
+
+## Companion plugin
+
+Consume this server from a voice assistant via the [companion TTS plugin](https://github.com/OpenVoiceOS/ovos-tts-server-plugin).
 
 ## Development
 
@@ -101,6 +144,13 @@ Each plugin can ship its own Dockerfile in its repository using `ovos-tts-server
 pip install -e ".[audio,test]"
 pytest test/ -v
 ```
+
+## Documentation
+
+- [API compatibility reference](docs/api-compatibility.md) — every vendor prefix, endpoint, and SDK snippet
+- [Voice & language configuration](docs/configuration.md) — how requests map to the plugin
+- [Audio format conversion](docs/audio-formats.md) — `convert_audio()` and the `[audio]` extra
+- [Architecture overview](docs/index.md) — classes, entry points, request flow
 
 ---
 

--- a/docs/api-compatibility.md
+++ b/docs/api-compatibility.md
@@ -1,79 +1,268 @@
 # API Compatibility Reference
 
 `ovos-tts-server` exposes its underlying OVOS TTS plugin behind drop-in
-compatibility endpoints for popular cloud TTS APIs. Each vendor lives
-under its own URL prefix so multiple compat layers coexist with no path
-collisions.
+compatibility endpoints for popular cloud TTS APIs. Each vendor lives under its
+own URL prefix, so every compat layer is active simultaneously with no path
+collisions — point a client at the matching prefix and it works unmodified.
 
-All routers accept any auth token / API key from the client and silently
-ignore it — authentication is the responsibility of your reverse proxy.
+All routers accept any auth token / API key from the client and **silently
+ignore it** — authentication is the responsibility of your reverse proxy.
 
 Audio format conversion is provided by `ovos_tts_server.audio_utils.convert_audio()`.
-Install the `[audio]` extra (`pip install ovos-tts-server[audio]`) to enable
-non-WAV outputs via `pydub`.
+Install the `[audio]` extra (`pip install "ovos-tts-server[audio]"`) to enable
+non-WAV outputs via `pydub`; without it, non-WAV requests fall back to WAV. See
+[audio-formats.md](audio-formats.md).
 
-This document currently covers: **ElevenLabs (`/elevenlabs`)**.
-Other vendor sections are added by their respective compat-router PRs.
+## Vendors at a glance
+
+| Vendor | Prefix | Endpoint(s) | Response |
+| :--- | :--- | :--- | :--- |
+| [ElevenLabs](#elevenlabs-elevenlabs) | `/elevenlabs` | `GET /v1/voices`, `GET /v1/models`, `POST /v1/text-to-speech/{voice_id}` | binary audio / JSON |
+| [OpenAI](#openai-openai) | `/openai` | `POST /v1/audio/speech` | binary audio |
+| [Coqui](#coqui-coqui) | `/coqui` | `GET /api/tts` | binary WAV |
+| [Google Cloud TTS](#google-cloud-tts-google-tts) | `/google-tts` | `POST /v1/text:synthesize` | JSON (base64 audio) |
+| [Amazon Polly](#amazon-polly-amazon-polly) | `/amazon-polly` | `POST /v1/speech` | binary audio |
+| [Azure TTS](#azure-tts-azure-tts) | `/azure-tts` | `POST /cognitiveservices/v1` | binary audio |
+
+> **Kokoro / kokoro-fastapi** is OpenAI-compatible and needs no dedicated
+> router — point any OpenAI-compatible client at the `/openai` prefix
+> (`/openai/v1/audio/speech`).
+
+Examples below assume the server runs at `http://localhost:9666`.
 
 ---
 
 ## ElevenLabs (`/elevenlabs`)
 
-**Upstream sources**:
-- Python SDK: [elevenlabs/elevenlabs-python](https://github.com/elevenlabs/elevenlabs-python) — `text_to_speech.convert()` builds `POST /v1/text-to-speech/{voice_id}`
-- API reference: [ElevenLabs Text-to-Speech docs](https://elevenlabs.io/docs/api-reference/text-to-speech)
-- Node SDK: [elevenlabs/elevenlabs-js](https://github.com/elevenlabs/elevenlabs-js)
-
+**Upstream:** [elevenlabs/elevenlabs-python](https://github.com/elevenlabs/elevenlabs-python) ·
+[API reference](https://elevenlabs.io/docs/api-reference/text-to-speech) ·
+[Node SDK](https://github.com/elevenlabs/elevenlabs-js)
 
 | Method | Path | Description |
 | :--- | :--- | :--- |
-| GET | `/elevenlabs/v1/voices` | List available voices |
-| GET | `/elevenlabs/v1/models` | List available models |
+| GET | `/elevenlabs/v1/voices` | List voices from the plugin |
+| GET | `/elevenlabs/v1/models` | List models (one entry: the plugin) |
 | POST | `/elevenlabs/v1/text-to-speech/{voice_id}` | Synthesize speech |
 
-**Auth:** `xi-api-key` header (ignored).
+**Auth:** `xi-api-key` header (accepted, ignored).
+
+**Synthesis request** — path `voice_id` (use `default` for the plugin default),
+query `output_format` (default `mp3_44100_128`), JSON body:
+
+| Field | Type | Notes |
+| :--- | :--- | :--- |
+| `text` | str (required) | Text to synthesize |
+| `model_id` | str | Accepted, not forwarded |
+| `voice_settings` | object | `stability`, `similarity_boost`, `style`, `use_speaker_boost` — accepted, not forwarded |
+
+`output_format` is parsed for the container: `pcm_*` → PCM/WAV, `ulaw_*` → WAV,
+otherwise the leading token (`mp3_44100_128` → `mp3`). Falls back to WAV if pydub
+is absent.
 
 ```bash
 # List voices
-curl -H "xi-api-key: fake" http://localhost:9666/elevenlabs/v1/voices
+curl -H "xi-api-key: x" http://localhost:9666/elevenlabs/v1/voices
 
 # Synthesize
-curl -X POST \
-  -H "xi-api-key: fake" \
-  -H "Content-Type: application/json" \
+curl -X POST -H "xi-api-key: x" -H "Content-Type: application/json" \
   -d '{"text": "hello world"}' \
   "http://localhost:9666/elevenlabs/v1/text-to-speech/default?output_format=mp3_44100_128" \
   -o out.mp3
 ```
 
-`output_format` values: `mp3_44100_128`, `pcm_16000`, `ulaw_8000`, etc. Falls back to WAV if pydub absent.
+**Point the SDK at this server:**
 
----
-
-### Pointing apps at this server
-
-ElevenLabs SDKs accept a custom base URL. Point it at `http://localhost:9666/elevenlabs`.
-
-**Python SDK** ([`elevenlabs`](https://github.com/elevenlabs/elevenlabs-python)):
 ```python
 from elevenlabs.client import ElevenLabs
 client = ElevenLabs(api_key="ignored", base_url="http://localhost:9666/elevenlabs")
 ```
 
-**Environment variable** (community convention used by many apps):
-```bash
-export ELEVENLABS_BASE_URL=http://localhost:9666/elevenlabs
-export ELEVENLABS_API_KEY=ignored
-```
-
-**Node SDK** (`@elevenlabs/elevenlabs-js`):
 ```js
+// @elevenlabs/elevenlabs-js
 new ElevenLabsClient({ apiKey: "ignored", baseUrl: "http://localhost:9666/elevenlabs" });
 ```
 
-**curl**:
+---
+
+## OpenAI (`/openai`)
+
+**Upstream:** [openai-python](https://github.com/openai/openai-python) ·
+[Audio/speech reference](https://platform.openai.com/docs/api-reference/audio/createSpeech)
+
+| Method | Path | Description |
+| :--- | :--- | :--- |
+| POST | `/openai/v1/audio/speech` | Synthesize speech |
+
+**Auth:** `Authorization: Bearer …` header (accepted, ignored).
+
+JSON body:
+
+| Field | Type | Notes |
+| :--- | :--- | :--- |
+| `input` | str (required) | Text to synthesize (≤ 4096 chars) |
+| `model` | str | Default `tts-1`; accepted, not forwarded |
+| `voice` | str | Default `alloy`; accepted, not forwarded |
+| `response_format` | str | Default `mp3`; maps to the output container |
+| `speed` | float | `0.25`–`4.0`; accepted, not forwarded |
+
 ```bash
-curl -X POST -H "xi-api-key: x" -H "Content-Type: application/json" \
-  -d '{"text": "hello"}' \
-  "http://localhost:9666/elevenlabs/v1/text-to-speech/default" -o out.mp3
+curl -X POST -H "Authorization: Bearer sk-ignored" -H "Content-Type: application/json" \
+  -d '{"model": "tts-1", "input": "hello world", "voice": "alloy", "response_format": "wav"}' \
+  "http://localhost:9666/openai/v1/audio/speech" -o out.wav
 ```
+
+**Point the SDK at this server** (also works for kokoro-fastapi clients):
+
+```python
+from openai import OpenAI
+client = OpenAI(api_key="ignored", base_url="http://localhost:9666/openai/v1")
+client.audio.speech.create(model="tts-1", voice="alloy", input="hello world")
+```
+
+---
+
+## Coqui (`/coqui`)
+
+**Upstream:** [coqui-ai/TTS](https://github.com/coqui-ai/TTS) `server` API.
+
+| Method | Path | Description |
+| :--- | :--- | :--- |
+| GET | `/coqui/api/tts` | Synthesize speech (returns WAV) |
+
+Query parameters:
+
+| Name | Type | Notes |
+| :--- | :--- | :--- |
+| `text` | str (required) | Text to synthesize |
+| `speaker_id` | str | Mapped to `voice=` |
+| `language_id` | str | Mapped to `lang=` |
+
+Always returns `audio/wav` (no format conversion).
+
+```bash
+curl "http://localhost:9666/coqui/api/tts?text=hello%20world&language_id=en" -o out.wav
+```
+
+---
+
+## Google Cloud TTS (`/google-tts`)
+
+**Upstream:** [google-cloud-texttospeech](https://github.com/googleapis/google-cloud-python) ·
+[REST reference](https://cloud.google.com/text-to-speech/docs/reference/rest/v1/text/synthesize)
+
+| Method | Path | Description |
+| :--- | :--- | :--- |
+| POST | `/google-tts/v1/text:synthesize` | Synthesize speech |
+
+**Auth:** `key` query param or `Authorization` header (accepted, ignored).
+
+JSON body (Google `SynthesizeSpeech` shape):
+
+| Field | Notes |
+| :--- | :--- |
+| `input.text` / `input.ssml` | Text or SSML to synthesize (`ssml` wins) |
+| `voice.languageCode` | Default `en-US`; mapped to `lang=` |
+| `voice.name` | Mapped to `voice=` |
+| `voice.ssmlGender` | Accepted, not forwarded |
+| `audioConfig.audioEncoding` | `MP3`→mp3, `LINEAR16`→wav, `OGG_OPUS`→ogg, `MULAW`/`ALAW`→wav |
+| `audioConfig.speakingRate` / `pitch` / `volumeGainDb` / `sampleRateHertz` | Accepted, not forwarded |
+
+Response is JSON with the audio as base64 in `audioContent` (matching Google's API):
+
+```json
+{ "audioContent": "<base64-encoded audio>" }
+```
+
+```bash
+curl -X POST -H "Content-Type: application/json" \
+  -d '{"input": {"text": "hello world"},
+       "voice": {"languageCode": "en-US"},
+       "audioConfig": {"audioEncoding": "MP3"}}' \
+  "http://localhost:9666/google-tts/v1/text:synthesize"
+```
+
+> The official `google-cloud-texttospeech` SDK defaults to gRPC over TLS and
+> can't be repointed at a plaintext local server; use the REST endpoint above
+> directly (any HTTP client) or a TLS-terminating reverse proxy.
+
+---
+
+## Amazon Polly (`/amazon-polly`)
+
+**Upstream:** [boto3 Polly](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/polly.html) ·
+[SynthesizeSpeech API](https://docs.aws.amazon.com/polly/latest/dg/API_SynthesizeSpeech.html)
+
+| Method | Path | Description |
+| :--- | :--- | :--- |
+| POST | `/amazon-polly/v1/speech` | Synthesize speech |
+
+**Auth:** AWS SigV4 `Authorization` header (accepted, ignored).
+
+JSON body (Polly `SynthesizeSpeech` shape):
+
+| Field | Type | Notes |
+| :--- | :--- | :--- |
+| `Text` | str (required) | Text to synthesize |
+| `VoiceId` | str | Default `Joanna`; mapped to `voice=` |
+| `OutputFormat` | str | `mp3`→mp3, `ogg_vorbis`→ogg, `pcm`→wav, `json`→mp3 |
+| `LanguageCode` | str | Mapped to `lang=` |
+| `Engine` / `TextType` / `SampleRate` | — | Accepted, not forwarded |
+
+```bash
+curl -X POST -H "Content-Type: application/json" \
+  -d '{"Text": "hello world", "VoiceId": "Joanna", "OutputFormat": "mp3"}' \
+  "http://localhost:9666/amazon-polly/v1/speech" -o out.mp3
+```
+
+---
+
+## Azure TTS (`/azure-tts`)
+
+**Upstream:** [azure-cognitiveservices-speech](https://pypi.org/project/azure-cognitiveservices-speech/) ·
+[REST reference](https://learn.microsoft.com/azure/ai-services/speech-service/rest-text-to-speech)
+
+| Method | Path | Description |
+| :--- | :--- | :--- |
+| POST | `/azure-tts/cognitiveservices/v1` | Synthesize speech from SSML |
+
+**Auth:** `Ocp-Apim-Subscription-Key` header (accepted, ignored).
+
+The request body is raw **SSML**. The router extracts the voice from
+`<voice name="…">` (→ `voice=`) and the language from `xml:lang="…"` (→ `lang=`),
+then synthesizes the stripped text. The output container is chosen from the
+`X-Microsoft-OutputFormat` header: values containing `mp3` → mp3,
+`pcm`/`wav`/`riff` → wav, `ogg`/`opus` → ogg (default mp3).
+
+```bash
+curl -X POST \
+  -H "Ocp-Apim-Subscription-Key: ignored" \
+  -H "Content-Type: application/ssml+xml" \
+  -H "X-Microsoft-OutputFormat: audio-16khz-128kbitrate-mono-mp3" \
+  -d '<speak version="1.0" xml:lang="en-US"><voice name="en-US-JennyNeural">hello world</voice></speak>' \
+  "http://localhost:9666/azure-tts/cognitiveservices/v1" -o out.mp3
+```
+
+### WebSocket bridge (optional)
+
+`ovos_tts_server.routers.azure_ws.make_azure_ws_router()` provides a WebSocket
+endpoint (`/azure-tts/cognitiveservices/websocket/v1`) compatible with the Azure
+Speech SDK's `speak_text_async()` / `speak_ssml_async()` calls. It is **not**
+registered by default — include it in your own app if you need it:
+
+```python
+from ovos_tts_server import start_tts_server
+from ovos_tts_server.routers.azure_ws import make_azure_ws_router
+
+app, engine = start_tts_server("ovos-tts-plugin-piper")
+app.include_router(make_azure_ws_router(engine))
+```
+
+---
+
+## How parameters reach the plugin
+
+Every router boils its vendor-specific request down to two optional kwargs —
+`voice=` and `lang=` — passed to `engine.synthesize(text, **kwargs)`. Parameters
+a plugin can't act on (speed, pitch, model id, voice settings, …) are accepted
+for wire-compatibility and ignored. See [configuration.md](configuration.md) for
+the full flow.

--- a/docs/audio-formats.md
+++ b/docs/audio-formats.md
@@ -1,33 +1,48 @@
 # Audio Format Conversion
 
-## `convert_audio(wav_path, fmt)` — `audio_utils.py`
+TTS plugins produce WAV. When a client asks for another container (mp3, ogg, …),
+the compat routers convert it with a single helper.
 
-Converts a WAV file produced by the TTS plugin to the requested output format.
+## `convert_audio(wav_path, fmt)` — `ovos_tts_server/audio_utils.py`
 
 ```python
 def convert_audio(wav_path: str, fmt: str) -> Tuple[bytes, str]:
     ...
 ```
 
-**Returns:** `(audio_bytes, mime_type)`
+**Returns:** `(audio_bytes, mime_type)`.
 
 ### Format handling
 
 | `fmt` value | Behaviour | MIME type |
 | :--- | :--- | :--- |
-| `"wav"` or `"pcm"` | WAV bytes returned directly | `audio/wav` |
+| `"wav"` or `"pcm"` | WAV bytes returned directly (no conversion) | `audio/wav` |
 | `"mp3"` | pydub export as MP3 | `audio/mpeg` |
 | `"ogg"` | pydub export as OGG | `audio/ogg` |
 | `"flac"` | pydub export as FLAC | `audio/flac` |
 | `"aac"` | pydub export as AAC | `audio/aac` |
-| any other | pydub export, MIME `audio/<fmt>` | dynamic |
+| any other | pydub export, MIME `audio/<fmt>` | `audio/<fmt>` |
 
-### pydub optional dependency
+The `fmt` argument is lower-cased before matching.
 
-pydub is an optional dependency (`pyproject.toml` `[project.optional-dependencies] audio = ["pydub"]`).
+### `pydub` is optional
 
-When pydub is **absent**, any non-WAV format falls back to WAV bytes:
-- The returned MIME type is still `audio/wav`.
-- Routers that consume this helper may add an `X-Audio-Format: wav` response header to signal the fallback.
+`pydub` lives in the `[audio]` extra
+(`[project.optional-dependencies] audio = ["pydub"]`). Install it to enable
+non-WAV output:
 
-Vendor-specific format-string normalisation (e.g. compound output_format strings) is documented alongside the router that uses it.
+```bash
+pip install "ovos-tts-server[audio]"
+```
+
+When `pydub` is **absent**, any non-WAV request degrades gracefully: the original
+WAV bytes are returned with MIME type `audio/wav`. The request still succeeds —
+the client simply receives WAV instead of the requested container.
+
+### Vendor format strings
+
+Each compat router normalises its vendor's format identifier to one of the
+`fmt` values above before calling `convert_audio()` — for example ElevenLabs'
+`mp3_44100_128` → `mp3`, Google's `LINEAR16` → `wav`, Polly's `ogg_vorbis` →
+`ogg`. Those mappings are documented per vendor in
+[api-compatibility.md](api-compatibility.md).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,17 +1,73 @@
 # Voice & Language Configuration
 
+This page explains how a TTS request becomes a call to your plugin, and how
+voices and languages are resolved.
+
+## Plugin configuration
+
+The plugin is configured exactly as it would be inside an assistant — via
+`mycroft.conf`. The server reads the `tts` section at startup:
+
+```json
+{
+  "tts": {
+    "module": "ovos-tts-plugin-piper",
+    "ovos-tts-plugin-piper": {
+      "model": "alan-low",
+      "lang": "en-us"
+    }
+  }
+}
+```
+
+`TTSEngineWrapper` loads the plugin named by `module` (or the `--engine` flag)
+and passes its config block to the plugin. The `--cache` flag sets
+`persist_cache` so generated audio is kept on disk across requests.
+
 ## How voice and language flow to the plugin
 
-Each compat router translates vendor-specific parameters into `voice=` and `lang=` kwargs passed to `engine.synthesize(utterance, **kwargs)`. The exact mapping is documented alongside each router's PR.
+Each compat router translates its vendor-specific parameters into `voice=` and
+`lang=` keyword arguments, which are forwarded to the plugin:
 
-## TTSEngineWrapper.synthesize
+```
+vendor request → router → engine.synthesize(text, voice=..., lang=...) → plugin
+```
 
-`TTSEngineWrapper.synthesize(utterance, voice=None, lang=None, **kwargs) → Tuple[str, Optional[str]]`
+For example: Coqui's `speaker_id`/`language_id`, Google's `voice.name`/
+`voice.languageCode`, Polly's `VoiceId`/`LanguageCode`, and Azure's SSML
+`<voice name=…>` / `xml:lang=…` all collapse to the same two kwargs. Parameters a
+plugin can't act on (speed, pitch, model id, …) are accepted for
+wire-compatibility and ignored. Per-vendor mappings are tabulated in
+[api-compatibility.md](api-compatibility.md).
 
-Returns `(wav_path, phonemes_or_None)`. The WAV file is then passed to `convert_audio()` if a non-WAV output format is requested.
+On the native endpoints (`/synthesize/{utterance}`, `/v2/synthesize`), **any**
+extra query parameter is forwarded verbatim to the plugin, so plugin-specific
+options work without a dedicated mapping.
+
+## `TTSEngineWrapper.synthesize`
+
+```python
+TTSEngineWrapper.synthesize(utterance: str, **kwargs) -> Tuple[str, Optional[str]]
+```
+
+Validates SSML, calls the plugin, and returns `(wav_path, phonemes_or_None)`.
+`kwargs` (typically `voice=` and `lang=`) are forwarded to the plugin. The WAV
+file is then passed to [`convert_audio()`](audio-formats.md) when a non-WAV
+output format is requested.
 
 Defined in `ovos_tts_server/__init__.py`.
 
-## Voices list
+## Languages
 
-`engine.voices` is populated from the loaded plugin (`available_voices` attribute, if present). Routers that expose a `/voices` endpoint read this list directly; routers may fall back to a single `"default"` voice entry if the plugin reports no voices.
+`engine.langs` returns the plugin's `available_languages`, or a single-element
+list with the wrapper's default language (from config, global `lang`, or `mul`)
+when the plugin doesn't report any. It is surfaced by `GET /status`
+(`langs` / `default_lang`) and by the ElevenLabs `/v1/models` listing.
+
+## Voices
+
+`engine.voices` is populated from the loaded plugin's `available_voices`
+attribute, if present (a list of strings or dicts); otherwise it is empty.
+Routers that expose a voices listing (e.g. ElevenLabs `/v1/voices`) read this
+list directly and fall back to a single `"default"` entry when the plugin
+reports none.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,41 +1,86 @@
-# ovos-tts-server
+# ovos-tts-server — Architecture Overview
 
-HTTP server that exposes any OVOS TTS plugin as a REST service using FastAPI.
+An HTTP server that exposes any OVOS TTS plugin as a REST service using
+[FastAPI](https://fastapi.tiangolo.com/). It is **stateless**: each request
+loads a plugin (once, at startup), calls it, and returns the generated audio.
 
-## Overview
+For installation and usage, start with the [README](../README.md).
 
-`ovos-tts-server` loads an OVOS TTS plugin at startup and serves synthesis requests over HTTP. It is stateless: each request calls the plugin and returns the generated audio file.
+## Request flow
 
-## Endpoints
+```
+HTTP request
+   │
+   ▼
+FastAPI route (core endpoint or compat router)
+   │   translate vendor params → voice=/lang= kwargs
+   ▼
+TTSEngineWrapper.synthesize(text, **kwargs)
+   │   → (wav_path, phonemes)
+   ▼
+convert_audio(wav_path, fmt)   # only if a non-WAV format was requested
+   │   → (audio_bytes, mime_type)
+   ▼
+HTTP response (audio file / bytes / base64 JSON, per vendor)
+```
+
+## Native endpoints
 
 | Method | Path | Description |
 | :--- | :--- | :--- |
 | GET | `/status` | Plugin name, supported languages, default voice/model |
-| GET | `/v2/synthesize?utterance=<text>[&lang=...][&voice=...]` | Primary synthesis endpoint — returns WAV audio |
+| GET | `/v2/synthesize?utterance=<text>[&lang=…][&voice=…]` | Primary synthesis endpoint — returns WAV audio |
 | GET | `/synthesize/<utterance>` | Legacy path-based synthesis endpoint |
 
-Third-party API compatibility endpoints (MaryTTS, ElevenLabs, OpenAI, Coqui, Google, Polly, Azure, Piper) are added by their respective compat-router PRs and live under per-vendor URL prefixes. See [api-compatibility.md](api-compatibility.md).
+Extra query parameters are forwarded to the plugin as synthesis options.
 
-## Key Classes
+## Compatibility routers
 
-- `TTSEngineWrapper` — loads and wraps a TTS plugin for dependency injection
-- `create_app(tts_engine)` — factory that returns the configured FastAPI app
-- `start_tts_server(tts_plugin, cache)` — top-level entry point used by `__main__`
+Drop-in compatibility endpoints for popular cloud TTS APIs are registered
+alongside the native endpoints, each under its own URL prefix:
 
-All defined in `ovos_tts_server/__init__.py`.
+| Vendor | Prefix |
+| :--- | :--- |
+| ElevenLabs | `/elevenlabs` |
+| OpenAI | `/openai` |
+| Coqui | `/coqui` |
+| Google Cloud TTS | `/google-tts` |
+| Amazon Polly | `/amazon-polly` |
+| Azure TTS | `/azure-tts` |
 
-## Entry Point
+Routers are wired up in `create_app()` (`ovos_tts_server/__init__.py`). An Azure
+WebSocket bridge router also exists but is not registered by default. See
+[api-compatibility.md](api-compatibility.md) for the full reference.
 
+## Key classes & functions
+
+All defined in `ovos_tts_server/__init__.py`:
+
+- **`TTSEngineWrapper`** — loads and wraps a TTS plugin for dependency
+  injection; exposes `synthesize()`, `voices`, and `langs`.
+- **`create_app(tts_engine) -> FastAPI`** — factory that builds the FastAPI app,
+  wires the native endpoints and every compat router, and enables permissive
+  CORS.
+- **`start_tts_server(tts_plugin, cache=False) -> (FastAPI, TTSEngineWrapper)`** —
+  top-level entry point used by `__main__`; constructs the wrapper and the app.
+
+## Entry point
+
+```bash
+ovos-tts-server --engine <plugin_name> [--host 0.0.0.0] [--port 9666] [--cache] [--lang en-us]
 ```
-ovos-tts-server --engine <plugin_name> [--host 0.0.0.0] [--port 9666] [--cache]
-```
+
+`__main__.py` parses the CLI, calls `start_tts_server(...)`, and runs the app
+with `uvicorn`.
 
 ## CORS
 
-All origins are allowed unconditionally (`CORSMiddleware(allow_origins=["*"])`).
+All origins are allowed unconditionally
+(`CORSMiddleware(allow_origins=["*"])`). Restrict this at your reverse proxy if
+the server is exposed publicly.
 
-## Documentation
+## Documentation map
 
-- [API Compatibility Reference](api-compatibility.md)
-- [Audio Format Conversion](audio-formats.md)
-- [Voice & Language Configuration](configuration.md)
+- [API Compatibility Reference](api-compatibility.md) — every vendor prefix, endpoint, parameter, and SDK snippet
+- [Voice & Language Configuration](configuration.md) — how a request maps to the plugin
+- [Audio Format Conversion](audio-formats.md) — `convert_audio()` and the `[audio]` extra


### PR DESCRIPTION
Modernizes the README and the entire `docs/` tree, and corrects several inaccuracies found by reading the routers on `dev`.

## What changed

**README.md**
- Drops compat routers that don't exist on `dev` (MaryTTS, Piper) from the vendor list; documents the **six that do**: ElevenLabs, OpenAI, Coqui, Google Cloud TTS, Amazon Polly, Azure.
- Uses the **real prefixes** — `/google-tts`, `/amazon-polly`, `/azure-tts` (the old text implied `/google`, `/polly`, `/azure`).
- Documents the previously-undocumented `--lang` CLI flag; adds a CLI options table.
- Adds badges, a quickstart, a compat table, and a Python API section.

**docs/api-compatibility.md**
- Was ElevenLabs-only ("other vendors added by their PRs"). Now a **full reference for all six routers**: endpoints, parameters, vendor→`voice=`/`lang=` mapping, output-format mapping, and curl + SDK base-URL snippets.
- Adds the optional Azure WebSocket bridge note.
- Notes that Kokoro/kokoro-fastapi clients use the `/openai` prefix.

**docs/index.md** — accurate architecture overview with a request-flow diagram and the real router prefixes.

**docs/configuration.md** — fixes the `synthesize()` signature (`synthesize(utterance, **kwargs)`) and expands the voice/language flow.

**docs/audio-formats.md** — removes the bogus `X-Audio-Format` header claim (no router sets it); documents the real `convert_audio()` format/MIME mapping and the pydub-absent WAV fallback.

## Notes

- Scoped to what is merged on `dev`. The open compat PRs (#94 MaryTTS, #113 Cartesia, #114 Deepgram, #115 PlayHT) each carry their own README/doc entries; expect small doc conflicts to resolve in whichever merges second.
- All facts were verified against the router source on `dev`; in-page anchor links validated.

Funded by NGI0 Commons Fund / NLnet (grant 101135429).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded README with HTTP API section, third-party vendor compatibility guidance, and Python API usage examples.
  * Comprehensive API compatibility reference covering multiple cloud TTS vendors with endpoint documentation and parameter mapping.
  * Enhanced configuration guide with request-flow explanation and concrete configuration examples.
  * Updated audio format documentation with conversion helper reference and vendor format normalization details.
  * Added architecture overview with request-flow diagram clarifying the full processing pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->