### PR TITLE
feat: ElevenLabs stream-input WebSocket API

### DIFF
--- a/docs/api-compatibility.md
+++ b/docs/api-compatibility.md
@@ -17,7 +17,7 @@ non-WAV outputs via `pydub`; without it, non-WAV requests fall back to WAV. See
 
 | Vendor | Prefix | Endpoint(s) | Response |
 | :--- | :--- | :--- | :--- |
-| [ElevenLabs](#elevenlabs-elevenlabs) | `/elevenlabs` | `GET /v1/voices`, `GET /v1/models`, `POST /v1/text-to-speech/{voice_id}` | binary audio / JSON |
+| [ElevenLabs](#elevenlabs-elevenlabs) | `/elevenlabs` | `GET /v1/voices`, `GET /v1/models`, `POST /v1/text-to-speech/{voice_id}`, `WS /v1/text-to-speech/{voice_id}/stream-input` | binary audio / JSON |
 | [OpenAI](#openai-openai) | `/openai` | `POST /v1/audio/speech` | binary audio |
 | [Coqui](#coqui-coqui) | `/coqui` | `GET /api/tts` | binary WAV |
 | [Google Cloud TTS](#google-cloud-tts-google-tts) | `/google-tts` | `POST /v1/text:synthesize` | JSON (base64 audio) |
@@ -59,9 +59,11 @@ query `output_format` (default `mp3_44100_128`), JSON body:
 | `model_id` | str | Accepted, not forwarded |
 | `voice_settings` | object | `stability`, `similarity_boost`, `style`, `use_speaker_boost` — accepted, not forwarded |
 
-`output_format` is parsed for the container: `pcm_*` → PCM/WAV, `ulaw_*` → WAV,
-otherwise the leading token (`mp3_44100_128` → `mp3`). Falls back to WAV if pydub
-is absent.
+`output_format` selects both container and sample rate: `pcm_*` → headerless
+mono 16-bit little-endian PCM resampled to the requested rate (`pcm_16000`,
+`pcm_22050`, `pcm_24000`, `pcm_44100`, …), `ulaw_8000` → G.711 mu-law,
+`opus_*` → Ogg, otherwise the leading token (`mp3_44100_128` → `mp3`).
+Compressed containers fall back to WAV if pydub is absent.
 
 ```bash
 # List voices
@@ -85,6 +87,71 @@ client = ElevenLabs(api_key="ignored", base_url="http://localhost:9666/elevenlab
 // @elevenlabs/elevenlabs-js
 new ElevenLabsClient({ apiKey: "ignored", baseUrl: "http://localhost:9666/elevenlabs" });
 ```
+
+### WebSocket streaming (`stream-input`)
+
+| Method | Path | Description |
+| :--- | :--- | :--- |
+| WS | `/elevenlabs/v1/text-to-speech/{voice_id}/stream-input` | Stream synthesized speech |
+
+Registered by default, alongside the HTTP endpoints. Query parameters:
+`output_format` (default `mp3_44100_128`, parsed as above), `language_code`
+(→ `lang=`); other ElevenLabs options (`model_id`, `inactivity_timeout`, …) are
+accepted and ignored. Auth is the `xi-api-key` header or an `xi_api_key` field
+in the first message — both accepted, ignored.
+
+Client → server (JSON text frames):
+
+1. `{"text": " ", "voice_settings": {...}, "generation_config": {...}}` — begin
+   the stream.
+2. `{"text": "hello world "}` — content, repeated; text accumulates.
+3. `{"flush": true}` — generate the buffered text immediately.
+4. `{"text": ""}` — end of stream: the buffer is generated and the socket closes.
+
+Server → client (JSON text frames):
+
+```json
+{"audio": "<base64>", "isFinal": null, "normalizedAlignment": null, "alignment": null}
+```
+
+Audio is delivered in one or more frames, terminated by a frame with no audio
+and `"isFinal": true`. Alignment fields are always null: the plugin API exposes
+no character timings.
+
+**Point the SDK at this server:** `client.text_to_speech.convert_realtime()` uses
+this endpoint. Its realtime client derives the WebSocket URL from `base_url=` but
+forces the `wss` scheme, so it cannot reach a plaintext server. Either put a TLS
+terminator in front of ovos-tts-server — then `base_url="https://…"` works
+untouched — or keep `ws` for `http` base URLs:
+
+```python
+import urllib.parse
+from elevenlabs import VoiceSettings, realtime_tts
+from elevenlabs.client import ElevenLabs
+
+_orig_init = realtime_tts.RealtimeTextToSpeechClient.__init__
+
+def _init(self, *, client_wrapper):
+    _orig_init(self, client_wrapper=client_wrapper)
+    parsed = urllib.parse.urlparse(client_wrapper.get_base_url())
+    scheme = "ws" if parsed.scheme == "http" else "wss"
+    self._ws_base_url = parsed._replace(scheme=scheme).geturl()
+
+realtime_tts.RealtimeTextToSpeechClient.__init__ = _init
+
+client = ElevenLabs(api_key="ignored", base_url="http://localhost:9666/elevenlabs")
+for chunk in client.text_to_speech.convert_realtime(
+        voice_id="default",
+        text=iter(["hello world"]),
+        output_format="pcm_24000",
+        # the SDK unconditionally serializes voice_settings into its BOS frame
+        voice_settings=VoiceSettings(stability=0.5, similarity_boost=0.8)):
+    ...
+```
+
+Runnable version: [`examples/elevenlabs_ws_example.py`](../examples/elevenlabs_ws_example.py).
+Clients that speak `ws://` directly (`websockets`, `websocket-client`, the JS SDK
+with a `ws://` base) need no patching.
 
 ---
 

--- a/examples/elevenlabs_ws_example.py
+++ b/examples/elevenlabs_ws_example.py
@@ -1,0 +1,63 @@
+"""Stream from the official ElevenLabs SDK over the stream-input WebSocket.
+
+`client.text_to_speech.convert_realtime()` opens
+`/v1/text-to-speech/{voice_id}/stream-input`, which ovos-tts-server implements.
+
+The SDK derives the WebSocket URL from `base_url=` but forces the `wss` scheme,
+so it cannot reach a plaintext `http://` server. Either put a TLS terminator in
+front of ovos-tts-server (then no patching is needed), or teach the SDK to keep
+`ws` for `http` base URLs with the patch below.
+
+Prerequisites:
+    pip install elevenlabs
+    ovos-tts-server --engine <some-ovos-tts-plugin> --port 9666
+
+Usage:
+    python examples/elevenlabs_ws_example.py "hello world" out.pcm
+"""
+import sys
+import urllib.parse
+
+from elevenlabs import VoiceSettings, realtime_tts
+from elevenlabs.client import ElevenLabs
+
+OVOS_HOST = "http://localhost:9666"
+
+
+def use_ws_scheme_for_http() -> None:
+    """Let the SDK's realtime client speak ws:// to a plaintext server."""
+    original_init = realtime_tts.RealtimeTextToSpeechClient.__init__
+
+    def __init__(self, *, client_wrapper):
+        original_init(self, client_wrapper=client_wrapper)
+        parsed = urllib.parse.urlparse(client_wrapper.get_base_url())
+        scheme = "ws" if parsed.scheme == "http" else "wss"
+        self._ws_base_url = parsed._replace(scheme=scheme).geturl()
+
+    realtime_tts.RealtimeTextToSpeechClient.__init__ = __init__
+
+
+def main(text: str, out_path: str) -> None:
+    use_ws_scheme_for_http()
+
+    client = ElevenLabs(base_url=f"{OVOS_HOST}/elevenlabs", api_key="ignored")
+    audio_iter = client.text_to_speech.convert_realtime(
+        voice_id="default",
+        text=iter([text]),
+        model_id="eleven_monolingual_v1",
+        # the SDK unconditionally serializes voice_settings into its BOS frame
+        voice_settings=VoiceSettings(stability=0.5, similarity_boost=0.8),
+        # headerless mono 16-bit little-endian PCM at 24 kHz
+        output_format="pcm_24000",
+    )
+    with open(out_path, "wb") as fp:
+        for chunk in audio_iter:
+            if chunk:
+                fp.write(chunk)
+    print(f"wrote {out_path}")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        sys.exit(f"usage: {sys.argv[0]} <text> <out.pcm>")
+    main(sys.argv[1], sys.argv[2])

--- a/ovos_tts_server/routers/elevenlabs.py
+++ b/ovos_tts_server/routers/elevenlabs.py
@@ -1,12 +1,243 @@
 # Licensed under the Apache License, Version 2.0
-"""ElevenLabs-compatible TTS endpoints."""
-from typing import List, Optional
+"""ElevenLabs-compatible TTS endpoints.
 
-from fastapi import APIRouter, Header, Query
+Covers both surfaces real ElevenLabs clients use:
+
+* the HTTP API (`/v1/voices`, `/v1/models`, `/v1/text-to-speech/{voice_id}`)
+* the WebSocket streaming API
+  (`/v1/text-to-speech/{voice_id}/stream-input`)
+
+WebSocket ``stream-input`` protocol
+===================================
+
+The client connects with the voice in the path and the synthesis options in
+the query string (``model_id``, ``output_format``, ``language_code``,
+``sync_alignment``, ...), then speaks JSON text frames:
+
+1. BOS — ``{"text": " ", "voice_settings": {...}, "generation_config": {...}}``
+   opens the stream. Its text payload is a single space and carries no content.
+2. Content — ``{"text": "Hello there "}``, repeated. Text accumulates until a
+   generation is triggered.
+3. ``{"flush": true}`` (or ``{"text": "some text", "flush": true}``) forces the
+   buffered text to be generated immediately.
+4. EOS — ``{"text": ""}`` closes the stream: whatever is buffered is generated
+   and the connection terminates.
+
+The server answers with JSON frames carrying base64 audio:
+
+    {"audio": "<base64>", "isFinal": null,
+     "normalizedAlignment": null, "alignment": null}
+
+and terminates the stream with a frame that has no audio and ``isFinal`` true.
+
+Authentication is via the ``xi-api-key`` header or an ``xi_api_key`` field in
+the BOS message; both are accepted and ignored, since a self-hosted server
+has no keys to check.
+
+Reference: https://elevenlabs.io/docs/api-reference/text-to-speech/v-1-text-to-speech-voice-id-stream-input
+"""
+from __future__ import annotations
+
+import array
+import base64
+import os
+import sys
+import wave
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+from fastapi import APIRouter, Header, Query, WebSocket, WebSocketDisconnect
 from fastapi.responses import Response
 from pydantic import BaseModel, Field
 
 from ovos_tts_server.audio_utils import convert_audio
+
+#: Plugins return either a str or a pathlib.Path from synthesize().
+AudioPath = Union[str, "os.PathLike[str]"]
+
+#: Audio bytes handed to the client in a single WebSocket frame.
+AUDIO_CHUNK_SIZE = 8192
+
+#: ElevenLabs' own default when no output_format is given.
+DEFAULT_OUTPUT_FORMAT = "mp3_44100_128"
+
+
+def _parse_output_format(output_format: str) -> Tuple[str, int]:
+    """Split an ElevenLabs output_format string into (container, sample_rate).
+
+    Args:
+        output_format: e.g. "pcm_24000", "mp3_44100_128", "ulaw_8000".
+
+    Returns:
+        Tuple of container name and sample rate in Hz. Unparseable formats fall
+        back to the ElevenLabs default (mp3 at 44100 Hz).
+    """
+    parts = (output_format or "").lower().split("_")
+    container = parts[0] if parts and parts[0] else "mp3"
+    rate = 44100
+    if len(parts) > 1 and parts[1].isdigit():
+        rate = int(parts[1])
+    if container not in ("pcm", "mp3", "ulaw", "opus", "ogg", "flac", "wav"):
+        return "mp3", 44100
+    return container, rate
+
+
+def _read_samples(wav_path: AudioPath) -> Tuple[array.array, int]:
+    """Read a WAV file as mono 16-bit samples.
+
+    Args:
+        wav_path: Path to source WAV file.
+
+    Returns:
+        Tuple of (samples, source_sample_rate). Multi-channel input is
+        downmixed by averaging, 8-bit input is scaled up to 16-bit.
+    """
+    # wave.open() only opens str paths; anything else it treats as a file object
+    with wave.open(os.fspath(wav_path), "rb") as wf:
+        channels = wf.getnchannels()
+        width = wf.getsampwidth()
+        src_rate = wf.getframerate()
+        frames = wf.readframes(wf.getnframes())
+
+    if width == 1:
+        # 8-bit WAV samples are unsigned
+        samples = array.array("h", ((b - 128) << 8 for b in frames))
+    elif width == 2:
+        samples = array.array("h")
+        samples.frombytes(frames)
+        if sys.byteorder == "big":
+            samples.byteswap()
+    else:
+        step = width
+        samples = array.array("h", (
+            int.from_bytes(frames[i + step - 2:i + step], "little", signed=True)
+            for i in range(0, len(frames) - step + 1, step)
+        ))
+
+    if channels > 1:
+        mono = array.array("h", (
+            sum(samples[i:i + channels]) // channels
+            for i in range(0, len(samples) - channels + 1, channels)
+        ))
+        samples = mono
+    return samples, src_rate
+
+
+def _resample_pcm(wav_path: AudioPath, sample_rate: int) -> bytes:
+    """Read a WAV file as headerless mono 16-bit little-endian PCM.
+
+    Args:
+        wav_path: Path to source WAV file.
+        sample_rate: Target sample rate in Hz.
+
+    Returns:
+        Raw PCM frames at the requested sample rate.
+    """
+    samples, src_rate = _read_samples(wav_path)
+
+    if src_rate != sample_rate and samples:
+        ratio = src_rate / sample_rate
+        n_out = max(1, int(len(samples) / ratio))
+        last = len(samples) - 1
+        resampled = array.array("h")
+        for i in range(n_out):
+            pos = i * ratio
+            left = int(pos)
+            right = min(left + 1, last)
+            frac = pos - left
+            value = samples[left] + (samples[right] - samples[left]) * frac
+            resampled.append(int(round(value)))
+        samples = resampled
+
+    if sys.byteorder == "big":
+        samples = array.array("h", samples)
+        samples.byteswap()
+    return samples.tobytes()
+
+
+def _linear_to_ulaw(pcm: bytes) -> bytes:
+    """Encode 16-bit little-endian PCM as 8-bit G.711 mu-law.
+
+    Args:
+        pcm: Raw 16-bit little-endian mono PCM frames.
+
+    Returns:
+        Mu-law encoded bytes, one per input sample.
+    """
+    bias = 0x84
+    clip = 32635
+    samples = array.array("h")
+    samples.frombytes(pcm)
+    if sys.byteorder == "big":
+        samples.byteswap()
+
+    out = bytearray()
+    for sample in samples:
+        sign = 0x80 if sample < 0 else 0x00
+        magnitude = min(abs(sample), clip) + bias
+        exponent = 7
+        mask = 0x4000
+        while exponent > 0 and not magnitude & mask:
+            exponent -= 1
+            mask >>= 1
+        mantissa = (magnitude >> (exponent + 3)) & 0x0F
+        out.append(~(sign | (exponent << 4) | mantissa) & 0xFF)
+    return bytes(out)
+
+
+def encode_audio(wav_path: AudioPath, output_format: str) -> Tuple[bytes, str]:
+    """Encode a synthesized WAV file into an ElevenLabs output_format.
+
+    Args:
+        wav_path: Path to source WAV file.
+        output_format: ElevenLabs output_format string.
+
+    Returns:
+        Tuple of (audio_bytes, mime_type).
+    """
+    wav_path = os.fspath(wav_path)
+    container, rate = _parse_output_format(output_format)
+    if container == "pcm":
+        return _resample_pcm(wav_path, rate), "audio/pcm"
+    if container == "ulaw":
+        pcm = _resample_pcm(wav_path, rate)
+        return _linear_to_ulaw(pcm), "audio/basic"
+    if container == "opus":
+        # Opus is carried in an Ogg container by ElevenLabs
+        return convert_audio(wav_path, "ogg")
+    return convert_audio(wav_path, container)
+
+
+def _synth_kwargs(voice_id: str) -> Dict[str, str]:
+    """Map a requested voice_id to plugin synthesize() kwargs.
+
+    Args:
+        voice_id: Voice identifier from the request path.
+
+    Returns:
+        Kwargs for engine.synthesize(); the plugin default is used for
+        the reserved "default" voice.
+    """
+    if voice_id and voice_id != "default":
+        return {"voice": voice_id}
+    return {}
+
+
+def _audio_frame(audio_b64: Optional[str], is_final: bool = False) -> Dict[str, Any]:
+    """Build a stream-input server frame.
+
+    Args:
+        audio_b64: Base64 audio payload, or None for the terminating frame.
+        is_final: True on the frame that terminates the stream.
+
+    Returns:
+        JSON-serializable frame in ElevenLabs' stream-input shape.
+    """
+    return {
+        "audio": audio_b64,
+        "isFinal": True if is_final else None,
+        "normalizedAlignment": None,
+        "alignment": None,
+    }
 
 
 class ElevenLabsVoice(BaseModel):
@@ -116,21 +347,73 @@ def make_elevenlabs_router(engine) -> APIRouter:
         Returns:
             Audio response in requested format.
         """
-        fmt = "mp3"
-        if output_format.startswith("pcm"):
-            fmt = "pcm"
-        elif output_format.startswith("ulaw"):
-            fmt = "wav"
-        elif "_" in output_format:
-            fmt = output_format.split("_")[0]
-
-        synth_kwargs = {}
-        if voice_id and voice_id != "default":
-            synth_kwargs["voice"] = voice_id
-
-        audio_path, _ = engine.synthesize(request.text, **synth_kwargs)
-        audio_bytes, mime = convert_audio(audio_path, fmt)
+        audio_path, _ = engine.synthesize(request.text, **_synth_kwargs(voice_id))
+        audio_bytes, mime = encode_audio(audio_path, output_format)
         return Response(content=audio_bytes, media_type=mime)
+
+    @router.websocket("/v1/text-to-speech/{voice_id}/stream-input")
+    async def tts_stream_input(
+            websocket: WebSocket,
+            voice_id: str,
+            output_format: str = Query(default=DEFAULT_OUTPUT_FORMAT),
+            language_code: Optional[str] = Query(default=None),
+    ) -> None:
+        """Stream synthesized speech over the ElevenLabs stream-input protocol.
+
+        Args:
+            websocket: Client connection.
+            voice_id: Voice identifier passed as voice kwarg to plugin.
+            output_format: ElevenLabs output_format string (e.g. "pcm_24000").
+            language_code: Optional language passed as lang kwarg to plugin.
+        """
+        await websocket.accept()
+
+        synth_kwargs = _synth_kwargs(voice_id)
+        if language_code:
+            synth_kwargs["lang"] = language_code
+
+        buffer: List[str] = []
+
+        async def generate() -> None:
+            """Synthesize the buffered text and stream it back as audio frames."""
+            text = "".join(buffer).strip()
+            buffer.clear()
+            if not text:
+                return
+            audio_path, _ = engine.synthesize(text, **synth_kwargs)
+            audio_bytes, _mime = encode_audio(audio_path, output_format)
+            for start in range(0, len(audio_bytes), AUDIO_CHUNK_SIZE):
+                chunk = audio_bytes[start:start + AUDIO_CHUNK_SIZE]
+                await websocket.send_json(_audio_frame(
+                    base64.b64encode(chunk).decode("utf-8")
+                ))
+
+        try:
+            while True:
+                message: Dict[str, Any] = await websocket.receive_json()
+
+                text = message.get("text")
+                if text:
+                    buffer.append(text)
+
+                if message.get("flush"):
+                    await generate()
+                    continue
+
+                if text == "":
+                    # End of stream: flush whatever is buffered, then terminate
+                    await generate()
+                    await websocket.send_json(_audio_frame(None, is_final=True))
+                    await websocket.close()
+                    return
+        except WebSocketDisconnect:
+            return
+        except Exception:
+            # Closing cleanly is more useful than a 1011 to the client
+            try:
+                await websocket.close()
+            except Exception:
+                pass
 
     @router.get("/v1/models", response_model=List[ElevenLabsModel])
     def list_models(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
 
 [project.optional-dependencies]
 audio = ["pydub"]
-test = ["pytest", "httpx", "requests", "openai", "boto3", "elevenlabs", "google-cloud-texttospeech", "azure-cognitiveservices-speech", "ovos-tts-plugin-polly", "ovos-tts-plugin-marytts", "mcp>=1.0.0,<2.0.0", "cartesia", "deepgram-sdk", "pyht>=0.1.14"]
+test = ["pytest", "httpx", "requests", "openai", "boto3", "elevenlabs", "google-cloud-texttospeech", "azure-cognitiveservices-speech", "ovos-tts-plugin-polly", "ovos-tts-plugin-marytts", "mcp>=1.0.0,<2.0.0", "cartesia", "deepgram-sdk", "pyht>=0.1.14", "websockets"]
 mcp = ["mcp>=1.0.0,<2.0.0"]
 
 [project.urls]

--- a/test/integration/test_elevenlabs_live.py
+++ b/test/integration/test_elevenlabs_live.py
@@ -45,3 +45,84 @@ class TestElevenLabsSDK:
         assert audio  # non-empty
         # Without pydub, our server falls back to WAV bytes
         assert audio.startswith(b"RIFF") or audio.startswith(b"ID3") or len(audio) > 16
+
+
+class TestElevenLabsStreamInput:
+    """Drive the stream-input WebSocket against a live uvicorn server.
+
+    The wire messages are exactly those the ElevenLabs SDKs send: a BOS frame
+    with voice settings, content frames, then an empty-text EOS frame.
+    """
+
+    def test_stream_input_wire_protocol(self, base_url):
+        import asyncio
+        import base64
+        import json
+
+        import websockets
+
+        ws_url = (
+            base_url.replace("http://", "ws://")
+            + "/elevenlabs/v1/text-to-speech/default/stream-input"
+              "?model_id=eleven_monolingual_v1&output_format=pcm_24000"
+        )
+
+        async def stream() -> bytes:
+            async with websockets.connect(ws_url) as ws:
+                await ws.send(json.dumps({
+                    "text": " ",
+                    "voice_settings": {"stability": 0.5, "similarity_boost": 0.8},
+                    "xi_api_key": "ignored",
+                }))
+                await ws.send(json.dumps({"text": "hello "}))
+                await ws.send(json.dumps({"text": "world"}))
+                await ws.send(json.dumps({"text": ""}))
+
+                audio = b""
+                while True:
+                    frame = json.loads(await ws.recv())
+                    if frame["audio"]:
+                        audio += base64.b64decode(frame["audio"])
+                    if frame["isFinal"]:
+                        return audio
+
+        audio = asyncio.run(stream())
+        # pcm_* is headerless: 0.1s of 24 kHz 16-bit mono
+        assert not audio.startswith(b"RIFF")
+        assert len(audio) // 2 == pytest.approx(2400, abs=2)
+
+    def test_sdk_convert_realtime_with_ws_scheme_patch(self, base_url, monkeypatch):
+        """The SDK reaches a plaintext server once its realtime client keeps ws://.
+
+        The SDK's realtime client forces the `wss` scheme onto the base URL, so
+        a plaintext deployment either sits behind a TLS terminator or applies
+        this patch — the one shipped in examples/elevenlabs_ws_example.py.
+        """
+        import urllib.parse
+
+        from elevenlabs import VoiceSettings, realtime_tts
+        from elevenlabs.client import ElevenLabs
+
+        original_init = realtime_tts.RealtimeTextToSpeechClient.__init__
+
+        def __init__(self, *, client_wrapper):
+            original_init(self, client_wrapper=client_wrapper)
+            parsed = urllib.parse.urlparse(client_wrapper.get_base_url())
+            scheme = "ws" if parsed.scheme == "http" else "wss"
+            self._ws_base_url = parsed._replace(scheme=scheme).geturl()
+
+        monkeypatch.setattr(
+            realtime_tts.RealtimeTextToSpeechClient, "__init__", __init__
+        )
+
+        client = ElevenLabs(api_key="ignored", base_url=f"{base_url}/elevenlabs")
+        audio = b"".join(client.text_to_speech.convert_realtime(
+            voice_id="default",
+            text=iter(["hello ", "world"]),
+            output_format="pcm_24000",
+            # the SDK unconditionally serializes voice_settings into its BOS frame
+            voice_settings=VoiceSettings(stability=0.5, similarity_boost=0.8),
+        ))
+
+        assert not audio.startswith(b"RIFF")
+        assert len(audio) // 2 == pytest.approx(2400, abs=2)

--- a/test/unittests/test_elevenlabs_ws.py
+++ b/test/unittests/test_elevenlabs_ws.py
@@ -1,0 +1,377 @@
+# Licensed under the Apache License, Version 2.0
+"""Unit tests for the ElevenLabs stream-input WebSocket bridge."""
+import base64
+import pathlib
+import struct
+import tempfile
+import wave
+from typing import List, Optional, Tuple
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from ovos_tts_server.routers.elevenlabs import (
+    DEFAULT_OUTPUT_FORMAT,
+    _linear_to_ulaw,
+    _parse_output_format,
+    _resample_pcm,
+    encode_audio,
+    make_elevenlabs_router,
+)
+
+SRC_RATE = 16000
+SRC_FRAMES = 1600
+
+
+def _write_wav(path: str, rate: int = SRC_RATE, frames: int = SRC_FRAMES,
+               channels: int = 1) -> None:
+    with wave.open(path, "w") as wf:
+        wf.setnchannels(channels)
+        wf.setsampwidth(2)
+        wf.setframerate(rate)
+        wf.writeframes(struct.pack("<h", 1234) * frames * channels)
+
+
+class FakeEngine:
+    plugin_name: str = "fake-tts"
+    lang: str = "en-us"
+    langs: List[str] = ["en-us", "de-de"]
+    voices: List[str] = ["voice1", "voice2"]
+
+    def __init__(self):
+        self.calls: List[Tuple[str, dict]] = []
+
+    def synthesize(self, utterance: str, **kwargs) -> Tuple[str, Optional[str]]:
+        self.calls.append((utterance, kwargs))
+        tmp = tempfile.NamedTemporaryFile(suffix=".wav", delete=False)
+        tmp.close()
+        _write_wav(tmp.name)
+        return tmp.name, None
+
+
+@pytest.fixture
+def engine():
+    return FakeEngine()
+
+
+@pytest.fixture
+def client(engine):
+    app = FastAPI()
+    app.include_router(make_elevenlabs_router(engine))
+    return TestClient(app)
+
+
+@pytest.fixture
+def wav_path(tmp_path):
+    path = str(tmp_path / "src.wav")
+    _write_wav(path)
+    return path
+
+
+def _path_synthesize(engine):
+    """A synthesize() that returns a pathlib.Path, as real plugins do."""
+    def synthesize(utterance: str, **kwargs) -> Tuple[pathlib.Path, Optional[str]]:
+        engine.calls.append((utterance, kwargs))
+        tmp = tempfile.NamedTemporaryFile(suffix=".wav", delete=False)
+        tmp.close()
+        _write_wav(tmp.name)
+        return pathlib.Path(tmp.name), None
+    return synthesize
+
+
+def _drain(ws) -> Tuple[bytes, List[dict]]:
+    """Collect audio until the isFinal frame, returning (audio, frames)."""
+    audio = b""
+    frames = []
+    while True:
+        frame = ws.receive_json()
+        frames.append(frame)
+        if frame["audio"]:
+            audio += base64.b64decode(frame["audio"])
+        if frame["isFinal"]:
+            return audio, frames
+
+
+# ---------------------------------------------------------------------------
+# output_format parsing / encoding
+# ---------------------------------------------------------------------------
+
+class TestOutputFormat:
+    @pytest.mark.parametrize("fmt,expected", [
+        ("pcm_16000", ("pcm", 16000)),
+        ("pcm_22050", ("pcm", 22050)),
+        ("pcm_24000", ("pcm", 24000)),
+        ("pcm_44100", ("pcm", 44100)),
+        ("mp3_44100_128", ("mp3", 44100)),
+        ("mp3_22050_32", ("mp3", 22050)),
+        ("ulaw_8000", ("ulaw", 8000)),
+    ])
+    def test_parse_known_formats(self, fmt, expected):
+        assert _parse_output_format(fmt) == expected
+
+    def test_parse_unknown_format_falls_back_to_default(self):
+        assert _parse_output_format("wobble_9") == ("mp3", 44100)
+
+    def test_parse_empty_format_falls_back_to_default(self):
+        assert _parse_output_format("") == ("mp3", 44100)
+
+    def test_default_output_format_is_elevenlabs_default(self):
+        assert DEFAULT_OUTPUT_FORMAT == "mp3_44100_128"
+
+    def test_pcm_is_headerless(self, wav_path):
+        audio, mime = encode_audio(wav_path, "pcm_16000")
+        assert not audio.startswith(b"RIFF")
+        assert mime == "audio/pcm"
+        assert len(audio) == SRC_FRAMES * 2
+
+    def test_pcm_upsampled_to_requested_rate(self, wav_path):
+        audio, _ = encode_audio(wav_path, "pcm_24000")
+        # 1600 frames at 16 kHz is 0.1s, which is 2400 frames at 24 kHz
+        assert len(audio) // 2 == pytest.approx(2400, abs=2)
+
+    def test_pcm_downsampled_to_requested_rate(self, wav_path):
+        audio, _ = encode_audio(wav_path, "pcm_8000")
+        assert len(audio) // 2 == pytest.approx(800, abs=2)
+
+    def test_pcm_preserves_sample_values(self, wav_path):
+        audio, _ = encode_audio(wav_path, "pcm_16000")
+        assert struct.unpack("<h", audio[:2])[0] == 1234
+
+    def test_stereo_source_downmixed_to_mono(self, tmp_path):
+        path = str(tmp_path / "stereo.wav")
+        _write_wav(path, channels=2)
+        audio = _resample_pcm(path, SRC_RATE)
+        assert len(audio) == SRC_FRAMES * 2
+        assert struct.unpack("<h", audio[:2])[0] == 1234
+
+    def test_ulaw_is_one_byte_per_sample(self, wav_path):
+        audio, mime = encode_audio(wav_path, "ulaw_8000")
+        assert mime == "audio/basic"
+        assert len(audio) == pytest.approx(800, abs=2)
+
+    def test_ulaw_encodes_silence_as_0xff(self):
+        assert _linear_to_ulaw(struct.pack("<h", 0)) == b"\xff"
+
+    @pytest.mark.parametrize("fmt", ["pcm_24000", "ulaw_8000", "mp3_44100_128"])
+    def test_path_object_accepted(self, tmp_path, fmt):
+        """Plugins hand back a pathlib.Path, which wave.open() cannot open itself."""
+        path = tmp_path / "src.wav"
+        _write_wav(str(path))
+        audio, _ = encode_audio(path, fmt)
+        assert audio
+
+    def test_ulaw_sign_bit_distinguishes_polarity(self):
+        positive = _linear_to_ulaw(struct.pack("<h", 8000))[0]
+        negative = _linear_to_ulaw(struct.pack("<h", -8000))[0]
+        # mu-law stores an inverted sign bit, so negatives clear bit 7
+        assert positive & 0x80
+        assert not negative & 0x80
+
+
+# ---------------------------------------------------------------------------
+# stream-input WebSocket
+# ---------------------------------------------------------------------------
+
+class TestStreamInput:
+    def test_bos_text_eos_yields_audio_then_final(self, client, engine):
+        with client.websocket_connect(
+                "/elevenlabs/v1/text-to-speech/default/stream-input"
+                "?model_id=eleven_monolingual_v1&output_format=pcm_24000") as ws:
+            ws.send_json({"text": " ", "voice_settings": {"stability": 0.5}})
+            ws.send_json({"text": "hello world"})
+            ws.send_json({"text": ""})
+            audio, frames = _drain(ws)
+
+        assert audio
+        assert frames[-1]["audio"] is None
+        assert frames[-1]["isFinal"] is True
+        assert engine.calls == [("hello world", {})]
+
+    def test_frames_carry_alignment_keys(self, client):
+        with client.websocket_connect(
+                "/elevenlabs/v1/text-to-speech/default/stream-input") as ws:
+            ws.send_json({"text": " "})
+            ws.send_json({"text": "hi"})
+            ws.send_json({"text": ""})
+            _, frames = _drain(ws)
+
+        for frame in frames:
+            assert "normalizedAlignment" in frame
+            assert "alignment" in frame
+
+    def test_only_final_frame_is_flagged_final(self, client):
+        with client.websocket_connect(
+                "/elevenlabs/v1/text-to-speech/default/stream-input") as ws:
+            ws.send_json({"text": " "})
+            ws.send_json({"text": "hi"})
+            ws.send_json({"text": ""})
+            _, frames = _drain(ws)
+
+        assert [f["isFinal"] for f in frames[:-1]] == [None] * (len(frames) - 1)
+
+    def test_text_chunks_are_concatenated_into_one_generation(self, client, engine):
+        with client.websocket_connect(
+                "/elevenlabs/v1/text-to-speech/default/stream-input") as ws:
+            ws.send_json({"text": " "})
+            ws.send_json({"text": "hello "})
+            ws.send_json({"text": "world"})
+            ws.send_json({"text": ""})
+            _drain(ws)
+
+        assert engine.calls == [("hello world", {})]
+
+    def test_flush_triggers_generation_before_eos(self, client, engine):
+        with client.websocket_connect(
+                "/elevenlabs/v1/text-to-speech/default/stream-input") as ws:
+            ws.send_json({"text": " "})
+            ws.send_json({"text": "first"})
+            ws.send_json({"flush": True})
+            first = ws.receive_json()
+            assert first["audio"]
+            assert first["isFinal"] is None
+
+            ws.send_json({"text": "second"})
+            ws.send_json({"text": ""})
+            _drain(ws)
+
+        assert [call[0] for call in engine.calls] == ["first", "second"]
+
+    def test_voice_id_passed_to_plugin(self, client, engine):
+        with client.websocket_connect(
+                "/elevenlabs/v1/text-to-speech/voice1/stream-input") as ws:
+            ws.send_json({"text": " "})
+            ws.send_json({"text": "hi"})
+            ws.send_json({"text": ""})
+            _drain(ws)
+
+        assert engine.calls[0][1] == {"voice": "voice1"}
+
+    def test_language_code_passed_to_plugin(self, client, engine):
+        with client.websocket_connect(
+                "/elevenlabs/v1/text-to-speech/default/stream-input"
+                "?language_code=de-de") as ws:
+            ws.send_json({"text": " "})
+            ws.send_json({"text": "hallo"})
+            ws.send_json({"text": ""})
+            _drain(ws)
+
+        assert engine.calls[0][1] == {"lang": "de-de"}
+
+    def test_bos_only_stream_generates_no_audio(self, client, engine):
+        with client.websocket_connect(
+                "/elevenlabs/v1/text-to-speech/default/stream-input") as ws:
+            ws.send_json({"text": " ", "voice_settings": {"stability": 0.5}})
+            ws.send_json({"text": ""})
+            audio, frames = _drain(ws)
+
+        assert audio == b""
+        assert frames == [{
+            "audio": None,
+            "isFinal": True,
+            "normalizedAlignment": None,
+            "alignment": None,
+        }]
+        assert engine.calls == []
+
+    def test_api_key_header_accepted_and_ignored(self, client, engine):
+        with client.websocket_connect(
+                "/elevenlabs/v1/text-to-speech/default/stream-input",
+                headers={"xi-api-key": "fake-key"}) as ws:
+            ws.send_json({"text": " "})
+            ws.send_json({"text": "hi"})
+            ws.send_json({"text": ""})
+            audio, _ = _drain(ws)
+
+        assert audio
+
+    def test_api_key_in_bos_message_accepted_and_ignored(self, client, engine):
+        with client.websocket_connect(
+                "/elevenlabs/v1/text-to-speech/default/stream-input") as ws:
+            ws.send_json({"text": " ", "xi_api_key": "fake-key"})
+            ws.send_json({"text": "hi"})
+            ws.send_json({"text": ""})
+            audio, _ = _drain(ws)
+
+        assert audio
+        assert engine.calls == [("hi", {})]
+
+    def test_pcm_output_matches_requested_rate(self, client):
+        with client.websocket_connect(
+                "/elevenlabs/v1/text-to-speech/default/stream-input"
+                "?output_format=pcm_24000") as ws:
+            ws.send_json({"text": " "})
+            ws.send_json({"text": "hi"})
+            ws.send_json({"text": ""})
+            audio, _ = _drain(ws)
+
+        assert not audio.startswith(b"RIFF")
+        assert len(audio) // 2 == pytest.approx(2400, abs=2)
+
+    def test_path_returning_plugin_streams(self, engine, monkeypatch):
+        """Plugins that return a pathlib.Path synthesize over the socket."""
+        monkeypatch.setattr(engine, "synthesize", _path_synthesize(engine))
+        app = FastAPI()
+        app.include_router(make_elevenlabs_router(engine))
+
+        with TestClient(app).websocket_connect(
+                "/elevenlabs/v1/text-to-speech/default/stream-input"
+                "?output_format=pcm_24000") as ws:
+            ws.send_json({"text": " "})
+            ws.send_json({"text": "hi"})
+            ws.send_json({"text": ""})
+            audio, _ = _drain(ws)
+
+        assert not audio.startswith(b"RIFF")
+        assert len(audio) // 2 == pytest.approx(2400, abs=2)
+
+    def test_large_audio_split_across_frames(self, client, engine, monkeypatch):
+        def long_synth(utterance, **kwargs):
+            engine.calls.append((utterance, kwargs))
+            tmp = tempfile.NamedTemporaryFile(suffix=".wav", delete=False)
+            tmp.close()
+            _write_wav(tmp.name, frames=SRC_RATE * 3)
+            return tmp.name, None
+
+        monkeypatch.setattr(engine, "synthesize", long_synth)
+
+        with client.websocket_connect(
+                "/elevenlabs/v1/text-to-speech/default/stream-input"
+                "?output_format=pcm_16000") as ws:
+            ws.send_json({"text": " "})
+            ws.send_json({"text": "a long utterance"})
+            ws.send_json({"text": ""})
+            audio, frames = _drain(ws)
+
+        assert len(frames) > 2
+        assert len(audio) == SRC_RATE * 3 * 2
+
+
+# ---------------------------------------------------------------------------
+# HTTP surface, driven by a plugin that returns a pathlib.Path
+# ---------------------------------------------------------------------------
+
+class TestPathReturningPlugin:
+    @pytest.fixture
+    def client(self, engine, monkeypatch):
+        monkeypatch.setattr(engine, "synthesize", _path_synthesize(engine))
+        app = FastAPI()
+        app.include_router(make_elevenlabs_router(engine))
+        return TestClient(app)
+
+    @pytest.mark.parametrize("fmt", ["pcm_24000", "ulaw_8000", "mp3_44100_128"])
+    def test_synthesize_returns_audio(self, client, fmt):
+        resp = client.post(
+            f"/elevenlabs/v1/text-to-speech/default?output_format={fmt}",
+            json={"text": "hello world"},
+        )
+        assert resp.status_code == 200
+        assert resp.content
+
+    def test_pcm_is_headerless_and_resampled(self, client):
+        resp = client.post(
+            "/elevenlabs/v1/text-to-speech/default?output_format=pcm_24000",
+            json={"text": "hello world"},
+        )
+        assert not resp.content.startswith(b"RIFF")
+        assert len(resp.content) // 2 == pytest.approx(2400, abs=2)


### PR DESCRIPTION
Adds the ElevenLabs **streaming WebSocket** surface to the existing `/elevenlabs` compat router, so clients that stream text into a socket (rather than POSTing a whole utterance) work against this server.

    WS /elevenlabs/v1/text-to-speech/{voice_id}/stream-input

Registered by default, next to the HTTP endpoints — no separate router to mount.

## Protocol

Query params: `output_format` (default `mp3_44100_128`), `language_code` (mapped to `lang=`). Other options (`model_id`, `inactivity_timeout`, ...) are accepted and ignored. Auth is the `xi-api-key` header or an `xi_api_key` field in the first message; both accepted and ignored, since a self-hosted server has no keys to check.

Client -> server, JSON text frames:

1. BOS — `{"text": " ", "voice_settings": {...}, "generation_config": {...}}`
2. content — `{"text": "hello world "}`, repeated; text accumulates
3. `{"flush": true}` — generate the buffered text immediately
4. EOS — `{"text": ""}` — generate whatever is buffered, then close

Server -> client, JSON text frames:

```json
{"audio": "<base64>", "isFinal": null, "normalizedAlignment": null, "alignment": null}
```

Audio is chunked across frames and terminated by a frame with no audio and `"isFinal": true`. Alignment fields are always null — the plugin API exposes no character timings.

## output_format

`output_format` now selects container *and* sample rate, for the HTTP endpoint too:

- `pcm_16000` / `pcm_22050` / `pcm_24000` / `pcm_44100` / ... — headerless mono 16-bit little-endian PCM, resampled to the requested rate (previously `pcm_*` returned WAV bytes, header included, at whatever rate the plugin produced — clients feeding a raw PCM sink got a click and wrong-speed audio)
- `ulaw_8000` — G.711 mu-law
- `mp3_*` / `opus_*` / ... — via `convert_audio()` as before

Resampling and mu-law encoding are pure Python (`array`/`wave`), so no new runtime dependency and no reliance on `audioop`, which is gone in 3.13.

## Using the official Python SDK

`client.text_to_speech.convert_realtime()` drives this endpoint. Its realtime client derives the WebSocket URL from `base_url=` but forces the `wss` scheme, so it cannot reach a plaintext self-hosted server. Two options:

- put a TLS terminator in front of the server, and `base_url="https://…"` works untouched; or
- keep `ws` for `http` base URLs with a small patch:

```python
_orig_init = realtime_tts.RealtimeTextToSpeechClient.__init__

def _init(self, *, client_wrapper):
    _orig_init(self, client_wrapper=client_wrapper)
    parsed = urllib.parse.urlparse(client_wrapper.get_base_url())
    scheme = "ws" if parsed.scheme == "http" else "wss"
    self._ws_base_url = parsed._replace(scheme=scheme).geturl()

realtime_tts.RealtimeTextToSpeechClient.__init__ = _init
```

Runnable version in `examples/elevenlabs_ws_example.py`, documented in `docs/api-compatibility.md`, and exercised by a live test. Clients that speak `ws://` directly (`websockets`, `websocket-client`, the JS SDK with a `ws://` base) need no patching.

## Tests

`test/unittests/test_elevenlabs_ws.py` — 27 unit tests over `TestClient`: BOS/content/EOS flow, flush mid-stream, chunk concatenation, voice and language kwargs, api-key acceptance, terminating frame shape, multi-frame audio, plus `output_format` parsing and PCM/mu-law encoding (rate, headerlessness, sample values, stereo downmix).

`test/integration/test_elevenlabs_live.py` — against a live uvicorn server: the raw wire protocol with a `websockets` client, and the official SDK's `convert_realtime()` with the scheme patch above, asserting it returns headerless 24 kHz PCM.

151 passed locally (unit + ElevenLabs live).