### PR TITLE
fix: cap mcp below 2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "simple FastAPI server to host TTS plugins as a service"
 readme = "README.md"
 license = "Apache-2.0"
 authors = [{name = "JarbasAi", email = "jarbasai@mailfence.com"}]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 
 keywords = [
     "plugin",
@@ -27,8 +27,8 @@ dependencies = [
 
 [project.optional-dependencies]
 audio = ["pydub"]
-test = ["pytest", "httpx", "requests", "openai", "boto3", "elevenlabs", "google-cloud-texttospeech", "azure-cognitiveservices-speech", "ovos-tts-plugin-polly", "ovos-tts-plugin-marytts", "mcp>=1.0.0", "cartesia", "deepgram-sdk", "pyht>=0.1.14"]
-mcp = ["mcp>=1.0.0"]
+test = ["pytest", "httpx", "requests", "openai", "boto3", "elevenlabs", "google-cloud-texttospeech", "azure-cognitiveservices-speech", "ovos-tts-plugin-polly", "ovos-tts-plugin-marytts", "mcp>=1.0.0,<2.0.0", "cartesia", "deepgram-sdk", "pyht>=0.1.14"]
+mcp = ["mcp>=1.0.0,<2.0.0"]
 
 [project.urls]
 Homepage = "https://github.com/OpenVoiceOS/ovos-tts-server"


### PR DESCRIPTION
CI is red on `dev` for every PR: all `build_tests` jobs fail collecting `test/unittests/test_mcp_server.py` and `test/end2end/test_e2e_mcp_utcp.py` with

```
ModuleNotFoundError: No module named 'mcp.server.fastmcp'
```

## Cause

`ovos_tts_server/mcp_server.py` imports `from mcp.server.fastmcp import FastMCP`. `pyproject.toml` declared `mcp>=1.0.0` with no upper bound, and the build workflow resolves dependencies with prereleases allowed, so CI installs **`mcp==2.0.0b1`** — and mcp 2.0 **removed** `mcp.server.fastmcp`.

Verified in a clean venv:

| mcp | `mcp.server.fastmcp` |
| :--- | :--- |
| 1.28.1 | present |
| 2.0.0b1 | gone |

Nothing in this repo changed; mcp did. The failure only surfaces on PRs because that is when the build workflow runs.

## Fix

Cap the dependency: `mcp>=1.0.0,<2.0.0`, in both the `mcp` extra and the `test` extra. With the cap in place, prerelease-allowing resolution installs mcp 1.28.1 and the MCP tests pass (32 passed locally, previously erroring at collection).

Supporting both import locations would mean tracking mcp 2.x's replacement API; the cap is the smaller correct change and can be lifted deliberately when mcp 2.x is adopted.

Also raises `requires-python` from `>=3.9` to `>=3.10`: `mcp` itself requires 3.10+, so the 3.9 floor was already unsatisfiable for anyone installing the `mcp` extra, and CI's lowest tested version is 3.10.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Raised the minimum supported Python version to 3.10.
  * Constrained the supported MCP package versions to the 1.x series.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->