### PR TITLE
fix: declare a websocket implementation as a runtime dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,13 +21,16 @@ dependencies = [
     "ovos-plugin-manager>=2.1.0,<3.0.0",
     "fastapi~=0.115",
     "uvicorn~=0.34",
+    # uvicorn serves WebSockets only when a ws implementation is importable;
+    # without one it answers the handshake with a 404
+    "websockets",
     "ovos-utils>=0.0.38",
     "pydantic",
 ]
 
 [project.optional-dependencies]
 audio = ["pydub"]
-test = ["pytest", "httpx", "requests", "openai", "boto3", "elevenlabs", "google-cloud-texttospeech", "azure-cognitiveservices-speech", "ovos-tts-plugin-polly", "ovos-tts-plugin-marytts", "mcp>=1.0.0,<2.0.0", "cartesia", "deepgram-sdk", "pyht>=0.1.14", "websockets"]
+test = ["pytest", "httpx", "requests", "openai", "boto3", "elevenlabs", "google-cloud-texttospeech", "azure-cognitiveservices-speech", "ovos-tts-plugin-polly", "ovos-tts-plugin-marytts", "mcp>=1.0.0,<2.0.0", "cartesia", "deepgram-sdk", "pyht>=0.1.14"]
 mcp = ["mcp>=1.0.0,<2.0.0"]
 
 [project.urls]

--- a/test/unittests/test_server.py
+++ b/test/unittests/test_server.py
@@ -132,3 +132,33 @@ class TestCORS:
         )
         assert r.status_code == 200
         assert r.headers.get("access-control-allow-origin") == "https://example.com"
+
+
+class TestWebSocketSupport:
+    """The WebSocket routers need uvicorn to have a ws implementation available.
+
+    uvicorn does not fail loudly when none is importable: it answers the
+    WebSocket handshake with a 404, so a registered route looks missing.
+    """
+
+    def test_uvicorn_resolves_a_ws_protocol_class(self):
+        from uvicorn.config import Config
+
+        config = Config(app=create_app(FakeEngine()), ws="auto")
+        config.load()
+        assert config.ws_protocol_class is not None
+
+    def test_stream_input_route_is_registered(self):
+        from fastapi.routing import APIWebSocketRoute
+
+        def ws_paths(routes):
+            """Collect WebSocket paths, descending into included routers."""
+            for route in routes:
+                if isinstance(route, APIWebSocketRoute):
+                    yield route.path
+                nested = getattr(route, "original_router", None) or route
+                if nested is not route:
+                    yield from ws_paths(getattr(nested, "routes", []) or [])
+
+        paths = list(ws_paths(create_app(FakeEngine()).routes))
+        assert "/elevenlabs/v1/text-to-speech/{voice_id}/stream-input" in paths


### PR DESCRIPTION
On a clean `pip install ovos-tts-server`, every WebSocket endpoint is dead: the handshake to `/elevenlabs/v1/text-to-speech/{voice_id}/stream-input` returns **HTTP 404**, as if the route were not registered.

## Cause

`uvicorn` is a runtime dependency, but no WebSocket implementation is. uvicorn can only serve WebSockets when `websockets` or `wsproto` is importable — and when neither is, it does not fail loudly. It resolves `ws_protocol_class` to `None` and answers the WebSocket handshake with a bare 404.

That makes the symptom maximally misleading: the route *is* registered (`APIWebSocketRoute` is present on `app.routes`), the `@router.websocket` decorator is right there in the module, and the HTTP surface of the same router works fine.

Reproduced with only the runtime deps installed:

```
>>> from uvicorn.config import Config
>>> c = Config(app=app, ws="auto"); c.load()
>>> c.ws_protocol_class
None
```

Installing `websockets` and restarting, with no other change, makes the endpoint stream audio normally.

This affects `routers/azure_ws.py` as well — that router predates the ElevenLabs one, so the dependency has arguably been missing for as long as the server has had a WebSocket surface.

## Why the tests did not catch it

`websockets` was declared in the `test` extra. The test environment therefore always had a ws implementation available, so both the `TestClient` unit tests and the live-uvicorn integration tests passed while a real install could not serve a single WebSocket frame. The dependency that made the tests pass was precisely the one missing at runtime.

## Fix

Move `websockets` from the `test` extra into the runtime `dependencies`. Chose the plain `websockets` pin over `uvicorn[standard]`: it is the minimal thing that makes the WebSocket routers work, and it avoids pulling `uvloop` and `httptools` into every install.

## Tests

Two regression tests in `test/unittests/test_server.py`, both of which fail without a ws implementation present:

- `test_uvicorn_resolves_a_ws_protocol_class` — loads a real `uvicorn.Config` with `ws="auto"` against the app and asserts `ws_protocol_class is not None`. This is the exact condition that decides 404-vs-working, so it fails on the dependency gap rather than on a downstream symptom.
- `test_stream_input_route_is_registered` — asserts the `stream-input` route is present on the app built by `create_app()`.

157 unit tests pass.