### PR TITLE
fix: address voice ids that span multiple path segments

### DIFF
--- a/docs/api-compatibility.md
+++ b/docs/api-compatibility.md
@@ -50,6 +50,10 @@ Examples below assume the server runs at `http://localhost:9666`.
 
 **Auth:** `xi-api-key` header (accepted, ignored).
 
+The `voice_id` may span several path segments, so voices named after a
+HuggingFace repo id (`OpenVoiceOS/phoonnx_ar_dii_espeak`) can be addressed
+directly — pass the id exactly as `GET /v1/voices` reports it.
+
 **Synthesis request** — path `voice_id` (use `default` for the plugin default),
 query `output_format` (default `mp3_44100_128`), JSON body:
 

--- a/ovos_tts_server/routers/elevenlabs.py
+++ b/ovos_tts_server/routers/elevenlabs.py
@@ -211,7 +211,8 @@ def _synth_kwargs(voice_id: str) -> Dict[str, str]:
     """Map a requested voice_id to plugin synthesize() kwargs.
 
     Args:
-        voice_id: Voice identifier from the request path.
+        voice_id: Voice identifier from the request path, verbatim — it may be
+            a multi-segment id such as a HuggingFace repo id.
 
     Returns:
         Kwargs for engine.synthesize(); the plugin default is used for
@@ -329,7 +330,9 @@ def make_elevenlabs_router(engine) -> APIRouter:
             voices = [ElevenLabsVoice(voice_id="default", name="default")]
         return ElevenLabsVoicesResponse(voices=voices)
 
-    @router.post("/v1/text-to-speech/{voice_id}")
+    # voice ids are often HuggingFace repo ids, which contain slashes, so the
+    # voice spans several path segments
+    @router.post("/v1/text-to-speech/{voice_id:path}")
     def tts_elevenlabs(
             voice_id: str,
             request: ElevenLabsTTSRequest,
@@ -351,7 +354,7 @@ def make_elevenlabs_router(engine) -> APIRouter:
         audio_bytes, mime = encode_audio(audio_path, output_format)
         return Response(content=audio_bytes, media_type=mime)
 
-    @router.websocket("/v1/text-to-speech/{voice_id}/stream-input")
+    @router.websocket("/v1/text-to-speech/{voice_id:path}/stream-input")
     async def tts_stream_input(
             websocket: WebSocket,
             voice_id: str,

--- a/test/unittests/test_elevenlabs_ws.py
+++ b/test/unittests/test_elevenlabs_ws.py
@@ -375,3 +375,56 @@ class TestPathReturningPlugin:
         )
         assert not resp.content.startswith(b"RIFF")
         assert len(resp.content) // 2 == pytest.approx(2400, abs=2)
+
+
+# ---------------------------------------------------------------------------
+# Voice ids spanning multiple path segments
+# ---------------------------------------------------------------------------
+
+#: Voice ids as plugins report them; HuggingFace repo ids contain slashes.
+VOICE_IDS = [
+    "voice1",
+    "OpenVoiceOS/phoonnx_ar_dii_espeak",
+    "hf_community/vadimbelsky/arabic-emirati-female-piper",
+]
+
+
+class TestMultiSegmentVoiceIds:
+    @pytest.mark.parametrize("voice_id", VOICE_IDS)
+    def test_http_passes_voice_id_verbatim(self, client, engine, voice_id):
+        resp = client.post(
+            f"/elevenlabs/v1/text-to-speech/{voice_id}",
+            json={"text": "hello world"},
+        )
+        assert resp.status_code == 200
+        assert engine.calls == [("hello world", {"voice": voice_id})]
+
+    @pytest.mark.parametrize("voice_id", VOICE_IDS)
+    def test_websocket_passes_voice_id_verbatim(self, client, engine, voice_id):
+        with client.websocket_connect(
+                f"/elevenlabs/v1/text-to-speech/{voice_id}/stream-input") as ws:
+            ws.send_json({"text": " "})
+            ws.send_json({"text": "hello world"})
+            ws.send_json({"text": ""})
+            audio, _ = _drain(ws)
+
+        assert audio
+        assert engine.calls == [("hello world", {"voice": voice_id})]
+
+    def test_http_default_voice_uses_plugin_default(self, client, engine):
+        resp = client.post(
+            "/elevenlabs/v1/text-to-speech/default",
+            json={"text": "hello world"},
+        )
+        assert resp.status_code == 200
+        assert engine.calls == [("hello world", {})]
+
+    def test_websocket_default_voice_uses_plugin_default(self, client, engine):
+        with client.websocket_connect(
+                "/elevenlabs/v1/text-to-speech/default/stream-input") as ws:
+            ws.send_json({"text": " "})
+            ws.send_json({"text": "hello world"})
+            ws.send_json({"text": ""})
+            _drain(ws)
+
+        assert engine.calls == [("hello world", {})]


### PR DESCRIPTION
Voices whose id contains a `/` cannot be addressed at all through the ElevenLabs router — they 404 on both the HTTP and the WebSocket surface.

This matters because real plugin voice ids are frequently HuggingFace repo ids:

- `OpenVoiceOS/phoonnx_ar_dii_espeak` — one slash
- `hf_community/vadimbelsky/arabic-emirati-female-piper` — two slashes

`GET /v1/voices` happily lists them, and then nothing can be synthesized with them.

## Cause

Both routes declared the voice as a single path segment:

```python
@router.post("/v1/text-to-speech/{voice_id}")
@router.websocket("/v1/text-to-speech/{voice_id}/stream-input")
```

A default path parameter does not match `/`, so the route simply does not bind. Percent-encoding the id is not a workaround: the ASGI path is decoded before routing. Reproduced against the current router — `default` and `voice1` return 200, both HuggingFace-style ids return 404.

## Fix

Declare the voice with Starlette's path converter, `{voice_id:path}`, on both routes, and hand the id to the plugin verbatim.

The greedy match still leaves the WebSocket route's `/stream-input` suffix bindable — Starlette backtracks — so the streaming endpoint keeps working for every id shape.

Slashes are deliberately **not** normalized (e.g. to hyphens). That would be lossy and unreversible: these ids already contain hyphens (`arabic-emirati-female-piper`) and some carry two slashes, so a normalized id cannot be mapped back to the real one. Any such scheme would silently mangle exactly the community voices people want. `default` keeps its existing meaning — the plugin's configured voice.

## Tests

Parametrized over a slash-free id, a one-slash id and a two-slash id, on both surfaces, asserting the plugin receives the id **verbatim** (`test_http_passes_voice_id_verbatim`, `test_websocket_passes_voice_id_verbatim`), plus `default` still resolving to the plugin default on both. The existing tests only ever used slash-free ids, which is why this went unnoticed.

163 unit tests pass.