### PR TITLE
test: match the stream-input route's path-converter voice id

### DIFF
--- a/test/unittests/test_server.py
+++ b/test/unittests/test_server.py
@@ -161,4 +161,4 @@ class TestWebSocketSupport:
                     yield from ws_paths(getattr(nested, "routes", []) or [])
 
         paths = list(ws_paths(create_app(FakeEngine()).routes))
-        assert "/elevenlabs/v1/text-to-speech/{voice_id}/stream-input" in paths
+        assert "/elevenlabs/v1/text-to-speech/{voice_id:path}/stream-input" in paths


### PR DESCRIPTION
The `TestWebSocketSupport::test_stream_input_route_is_registered` guard fails on `dev`, so CI is red for every open PR.

## Cause

The guard asserts the ElevenLabs `stream-input` WebSocket route is registered by matching its path string. The route was later changed to declare the voice with a path converter — `{voice_id:path}`, so voice ids can span multiple path segments — but the assertion still checked the bare `{voice_id}` form, which no longer appears in `app.routes`.

Two separately-correct changes that landed independently: the route path gained `:path`, the assertion kept the old string. The product route is correct; only the test string was stale.

## Fix

Update the assertion to `{voice_id:path}/stream-input`, matching the registered route. No product code changes.

11 tests in `test_server.py` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated WebSocket route validation to support voice identifiers containing path segments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->