### PR TITLE
fix: flow --lang into the plugin configuration

### DIFF
--- a/ovos_tts_server/__init__.py
+++ b/ovos_tts_server/__init__.py
@@ -9,17 +9,25 @@ from ovos_config import Configuration
 class TTSEngineWrapper:
     """Wrapper around an OVOS TTS engine for dependency injection."""
 
-    def __init__(self, plugin_name: str, cache: bool = False):
+    def __init__(self, plugin_name: str, cache: bool = False,
+                 lang: Optional[str] = None):
         """
         Create a TTSEngineWrapper by loading and configuring the named TTS plugin.
-        
+
         Parameters:
             plugin_name (str): Name of the TTS plugin to load.
             cache (bool): If True, persist generated audio cache across restarts.
+            lang (Optional[str]): Language code that overrides any configured
+                language for the plugin. Plugins select their default voice from
+                this language when no specific voice is configured. When None,
+                the plugin's configured language is used.
         """
         engine = load_tts_plugin(plugin_name)
         config = Configuration().get("tts", {}).get(plugin_name, {})
         config["persist_cache"] = cache
+        # An explicit lang takes precedence over the plugin's configured lang
+        if lang:
+            config["lang"] = lang
         self.engine = engine(config=config)
         self.engine.log_timestamps = True
         self.plugin_name = plugin_name
@@ -181,6 +189,7 @@ def start_tts_server(
     tts_plugin: str,
     cache: bool = False,
     enable_mcp: bool = False,
+    lang: Optional[str] = None,
 ) -> Tuple[FastAPI, TTSEngineWrapper]:
     """
     Initialize TTS engine and create FastAPI app.
@@ -190,11 +199,14 @@ def start_tts_server(
         cache: Whether to persist cached audio across reboots.
         enable_mcp: If True, mount the optional MCP server at ``/mcp``
             (requires ``pip install "ovos-tts-server[mcp]"``).
+        lang: Language code that overrides the plugin's configured language,
+            driving its default voice selection. When None, the configured
+            language is used.
 
     Returns:
         Tuple of FastAPI app and TTS engine wrapper.
     """
-    tts_engine = TTSEngineWrapper(plugin_name=tts_plugin, cache=cache)
+    tts_engine = TTSEngineWrapper(plugin_name=tts_plugin, cache=cache, lang=lang)
     app = create_app(tts_engine)
     if enable_mcp:
         from ovos_tts_server.mcp_server import mount_mcp

--- a/ovos_tts_server/__main__.py
+++ b/ovos_tts_server/__main__.py
@@ -27,8 +27,11 @@ def main():
                         default="0.0.0.0")
     parser.add_argument("--cache", help="save every synth to disk",
                         action="store_true")
-    parser.add_argument("--lang", help="default language supported by plugin",
-                        default="en-us")
+    parser.add_argument("--lang",
+                        help="language the plugin serves; selects its default "
+                             "voice when no voice is configured. Overrides the "
+                             "plugin's configured language.",
+                        default=None)
     parser.add_argument(
         "--mcp",
         help="mount MCP server at /mcp (requires ovos-tts-server[mcp])",
@@ -36,7 +39,8 @@ def main():
     )
     args = parser.parse_args()
 
-    server, engine = start_tts_server(args.engine, cache=bool(args.cache), enable_mcp=bool(args.mcp))
+    server, engine = start_tts_server(args.engine, cache=bool(args.cache),
+                                      enable_mcp=bool(args.mcp), lang=args.lang)
     LOG.info("Server Started")
     uvicorn.run(server, host=args.host, port=int(args.port))
 

--- a/test/unittests/test_engine_wrapper.py
+++ b/test/unittests/test_engine_wrapper.py
@@ -9,7 +9,8 @@ from unittest.mock import MagicMock, patch
 from ovos_tts_server import TTSEngineWrapper, start_tts_server
 
 
-def _patched_wrapper(plugin_name="fake-tts", cache=False, config_overrides=None):
+def _patched_wrapper(plugin_name="fake-tts", cache=False, config_overrides=None,
+                     lang=None, global_lang=None):
     """Create a TTSEngineWrapper with load_tts_plugin / Configuration mocked."""
     fake_plugin_cls = MagicMock()
     fake_engine = MagicMock()
@@ -24,29 +25,71 @@ def _patched_wrapper(plugin_name="fake-tts", cache=False, config_overrides=None)
     fake_engine.validate_ssml.side_effect = lambda x: x
 
     cfg_dict = {"tts": {plugin_name: config_overrides or {}}}
+    if global_lang is not None:
+        cfg_dict["lang"] = global_lang
     cfg = MagicMock()
     cfg.get.side_effect = lambda k, d=None: cfg_dict.get(k, d)
 
     with patch("ovos_tts_server.load_tts_plugin", return_value=fake_plugin_cls), \
          patch("ovos_tts_server.Configuration", return_value=cfg):
-        wrapper = TTSEngineWrapper(plugin_name=plugin_name, cache=cache)
-    return wrapper, fake_engine
+        wrapper = TTSEngineWrapper(plugin_name=plugin_name, cache=cache, lang=lang)
+    return wrapper, fake_engine, fake_plugin_cls
+
+
+def _plugin_config(fake_plugin_cls):
+    """Return the config dict the plugin was instantiated with."""
+    _, kwargs = fake_plugin_cls.call_args
+    return kwargs["config"]
 
 
 class TestTTSEngineWrapper:
     def test_initializes_with_plugin(self):
-        wrapper, engine = _patched_wrapper()
+        wrapper, engine, _ = _patched_wrapper()
         assert wrapper.plugin_name == "fake-tts"
         assert wrapper.engine is engine
         assert engine.log_timestamps is True
 
     def test_lang_falls_back_to_mul_when_no_config(self):
-        wrapper, _ = _patched_wrapper(config_overrides={})
+        wrapper, _, _ = _patched_wrapper(config_overrides={})
         assert wrapper.lang == "mul"
 
     def test_lang_from_plugin_config(self):
-        wrapper, _ = _patched_wrapper(config_overrides={"lang": "pt-pt"})
+        wrapper, _, _ = _patched_wrapper(config_overrides={"lang": "pt-pt"})
         assert wrapper.lang == "pt-pt"
+
+    def test_explicit_lang_reaches_plugin_and_wrapper(self):
+        wrapper, _, plugin_cls = _patched_wrapper(lang="ar")
+        assert wrapper.lang == "ar"
+        assert _plugin_config(plugin_cls)["lang"] == "ar"
+
+    def test_explicit_lang_overrides_configured_lang(self):
+        wrapper, _, plugin_cls = _patched_wrapper(
+            lang="ar", config_overrides={"lang": "pt-pt"})
+        assert wrapper.lang == "ar"
+        assert _plugin_config(plugin_cls)["lang"] == "ar"
+
+    def test_configured_lang_kept_when_no_explicit_lang(self):
+        wrapper, _, plugin_cls = _patched_wrapper(
+            lang=None, config_overrides={"lang": "ar"})
+        assert wrapper.lang == "ar"
+        assert _plugin_config(plugin_cls)["lang"] == "ar"
+
+    def test_explicit_lang_overrides_global_lang(self):
+        wrapper, _, plugin_cls = _patched_wrapper(lang="ar", global_lang="pt-pt")
+        assert wrapper.lang == "ar"
+        assert _plugin_config(plugin_cls)["lang"] == "ar"
+
+    def test_global_lang_used_when_no_explicit_or_plugin_lang(self):
+        wrapper, _, plugin_cls = _patched_wrapper(
+            lang=None, config_overrides={}, global_lang="pt-pt")
+        assert wrapper.lang == "pt-pt"
+        # nothing forced onto the plugin config when no explicit lang is given
+        assert "lang" not in _plugin_config(plugin_cls)
+
+    def test_no_lang_anywhere_falls_back_to_mul(self):
+        wrapper, _, plugin_cls = _patched_wrapper(lang=None, config_overrides={})
+        assert wrapper.lang == "mul"
+        assert "lang" not in _plugin_config(plugin_cls)
 
     def test_cache_flag_passed_to_plugin_config(self):
         with patch("ovos_tts_server.load_tts_plugin") as load, \
@@ -61,25 +104,25 @@ class TestTTSEngineWrapper:
             assert kwargs["config"]["persist_cache"] is True
 
     def test_langs_uses_engine_available_languages(self):
-        wrapper, _ = _patched_wrapper()
+        wrapper, _, _ = _patched_wrapper()
         assert wrapper.langs == ["en-us", "de-de"]
 
     def test_langs_falls_back_to_self_lang(self):
-        wrapper, engine = _patched_wrapper()
+        wrapper, engine, _ = _patched_wrapper()
         engine.available_languages = None
         assert wrapper.langs == [wrapper.lang]
 
     def test_voices_uses_available_voices(self):
-        wrapper, _ = _patched_wrapper()
+        wrapper, _, _ = _patched_wrapper()
         assert wrapper.voices == ["v1", "v2"]
 
     def test_voices_empty_when_attr_missing(self):
-        wrapper, engine = _patched_wrapper()
+        wrapper, engine, _ = _patched_wrapper()
         del engine.available_voices
         assert wrapper.voices == []
 
     def test_synthesize_returns_path_and_phonemes(self):
-        wrapper, engine = _patched_wrapper()
+        wrapper, engine, _ = _patched_wrapper()
         path, phonemes = wrapper.synthesize("hello", voice="v1")
         assert path == "/tmp/fake.wav"
         assert phonemes == "fake phonemes"

--- a/test/unittests/test_main.py
+++ b/test/unittests/test_main.py
@@ -21,12 +21,14 @@ class TestCLI:
             "--host", "127.0.0.1",
             "--port", "1234",
             "--cache",
+            "--lang", "ar",
         ])
         with patch("ovos_tts_server.__main__.start_tts_server") as start, \
              patch("ovos_tts_server.__main__.uvicorn") as uv:
             start.return_value = (MagicMock(name="app"), MagicMock(name="engine"))
             cli.main()
-            start.assert_called_once_with("fake-plugin", cache=True, enable_mcp=False)
+            start.assert_called_once_with(
+                "fake-plugin", cache=True, enable_mcp=False, lang="ar")
             uv.run.assert_called_once()
             _, kwargs = uv.run.call_args
             assert kwargs["host"] == "127.0.0.1"
@@ -41,7 +43,9 @@ class TestCLI:
             _, kwargs = uv.run.call_args
             assert kwargs["host"] == "0.0.0.0"
             assert kwargs["port"] == 9666
-            start.assert_called_once_with("x", cache=False, enable_mcp=False)
+            # no --lang given: nothing is forced onto the plugin config
+            start.assert_called_once_with(
+                "x", cache=False, enable_mcp=False, lang=None)
 
     def test_help_exits_zero(self, monkeypatch):
         monkeypatch.setattr(sys, "argv", ["ovos-tts-server", "--help"])


### PR DESCRIPTION
The `--lang` argument is parsed and then ignored. `start_tts_server()` never received it and `TTSEngineWrapper` derived the language purely from config, so `--lang ar` did nothing.

This matters because OVOS TTS plugins pick their default voice from their configured language (e.g. `get_default_voice(self.lang)` when no voice is set). So `--lang ar` should make a plugin serve its Arabic default voice, but instead the plugin loaded its built-in default (English) and tried to fetch that. This makes `--lang` actually select a plugin's language-default voice.

## Fix

Thread the value through: `main()` → `start_tts_server(..., lang=args.lang)` → `TTSEngineWrapper(plugin_name, cache, lang=...)`. When a lang is provided, the wrapper injects it into the config the plugin receives (`config["lang"] = lang`) before instantiating the plugin, and sets `self.lang` from the resulting config.

## Precedence

The `--lang` CLI default changes from `"en-us"` to `None`, and the lang is injected only when actually passed. So a user's configured `tts.<plugin>.lang` is no longer silently clobbered by the CLI default. Resulting order:

1. explicit `--lang` (CLI)
2. configured `tts.<plugin>.lang` (mycroft.conf)
3. global `Configuration` `lang`
4. `"mul"`

A specifically configured `voice` still wins over language-based default selection — untouched; lang only drives the default voice when no voice is set.

## Tests

In `test/unittests/test_engine_wrapper.py` (plugin and `Configuration` mocked, no model loads), asserting both `TTSEngineWrapper.lang` and the config actually handed to the plugin:

- explicit `--lang` reaches plugin + wrapper (`lang == "ar"`, config carries `lang: "ar"`)
- explicit `--lang` overrides a configured plugin lang
- configured plugin lang kept when no `--lang` (default no longer clobbers it)
- explicit `--lang` overrides the global lang
- global lang used when neither explicit nor plugin lang, and nothing forced onto plugin config
- no lang anywhere falls back to `"mul"`, nothing forced onto plugin config

Plus `test/unittests/test_main.py` updated to assert `--lang` flows into `start_tts_server` and that its absence passes `lang=None`.