### PR TITLE
fix: serve non-WAV plugin output through compat routers

### DIFF
--- a/ovos_tts_server/audio_utils.py
+++ b/ovos_tts_server/audio_utils.py
@@ -1,39 +1,91 @@
 # Licensed under the Apache License, Version 2.0
 import os
+import subprocess
+import tempfile
+import wave
 from typing import Tuple
 
 
-def convert_audio(wav_path: str, fmt: str) -> Tuple[bytes, str]:
-    """Convert WAV file to requested format.
+def _is_wav(path: str) -> bool:
+    """Return True if the file can be opened as a RIFF WAV."""
+    try:
+        with wave.open(path, "rb"):
+            return True
+    except (wave.Error, EOFError, OSError):
+        return False
+
+
+def _ensure_wav(path: str) -> Tuple[str, bool]:
+    """Return a path to a WAV file, transcoding non-WAV plugin output if needed.
+
+    TTS plugins may declare a non-WAV ``audio_ext`` (e.g. an mp3-only engine),
+    in which case synthesis yields audio the WAV/pydub decode path cannot read.
+    This transcodes such output to a temporary WAV so downstream conversion works.
 
     Args:
-        wav_path: Path to source WAV file.
+        path: Path to the synthesized audio file.
+
+    Returns:
+        Tuple of (wav_path, is_temp). ``is_temp`` is True when ``wav_path`` is a
+        freshly created temporary file the caller is responsible for removing.
+    """
+    if _is_wav(path):
+        return path, False
+
+    tmp = tempfile.NamedTemporaryFile(suffix=".wav", delete=False)
+    tmp.close()
+    try:
+        try:
+            from pydub import AudioSegment
+            AudioSegment.from_file(path).export(tmp.name, format="wav")
+        except ImportError:
+            subprocess.run(
+                ["ffmpeg", "-y", "-loglevel", "error", "-i", path, tmp.name],
+                check=True,
+            )
+    except Exception:
+        os.remove(tmp.name)
+        raise
+    return tmp.name, True
+
+
+def convert_audio(wav_path: str, fmt: str) -> Tuple[bytes, str]:
+    """Convert a synthesized audio file to the requested format.
+
+    Args:
+        wav_path: Path to the synthesized audio file. Non-WAV plugin output is
+            transcoded to WAV before decoding.
         fmt: Target audio format (e.g. "mp3", "wav", "pcm", "ogg").
 
     Returns:
         Tuple of (audio_bytes, mime_type). Falls back to WAV on ImportError.
     """
     fmt = fmt.lower()
-    with open(wav_path, "rb") as f:
-        wav_bytes = f.read()
-
-    if fmt in ("wav", "pcm"):
-        return wav_bytes, "audio/wav"
-
+    src_path, is_temp = _ensure_wav(wav_path)
     try:
-        from pydub import AudioSegment
-        import io
-        audio = AudioSegment.from_wav(wav_path)
-        buf = io.BytesIO()
-        pydub_fmt = "mp3" if fmt == "mp3" else fmt
-        audio.export(buf, format=pydub_fmt)
-        mime_map = {
-            "mp3": "audio/mpeg",
-            "ogg": "audio/ogg",
-            "flac": "audio/flac",
-            "aac": "audio/aac",
-        }
-        mime = mime_map.get(fmt, f"audio/{fmt}")
-        return buf.getvalue(), mime
-    except ImportError:
-        return wav_bytes, "audio/wav"
+        with open(src_path, "rb") as f:
+            wav_bytes = f.read()
+
+        if fmt in ("wav", "pcm"):
+            return wav_bytes, "audio/wav"
+
+        try:
+            from pydub import AudioSegment
+            import io
+            audio = AudioSegment.from_wav(src_path)
+            buf = io.BytesIO()
+            pydub_fmt = "mp3" if fmt == "mp3" else fmt
+            audio.export(buf, format=pydub_fmt)
+            mime_map = {
+                "mp3": "audio/mpeg",
+                "ogg": "audio/ogg",
+                "flac": "audio/flac",
+                "aac": "audio/aac",
+            }
+            mime = mime_map.get(fmt, f"audio/{fmt}")
+            return buf.getvalue(), mime
+        except ImportError:
+            return wav_bytes, "audio/wav"
+    finally:
+        if is_temp:
+            os.remove(src_path)

--- a/ovos_tts_server/routers/elevenlabs.py
+++ b/ovos_tts_server/routers/elevenlabs.py
@@ -49,7 +49,7 @@ from fastapi import APIRouter, Header, Query, WebSocket, WebSocketDisconnect
 from fastapi.responses import Response
 from pydantic import BaseModel, Field
 
-from ovos_tts_server.audio_utils import convert_audio
+from ovos_tts_server.audio_utils import _ensure_wav, convert_audio
 
 #: Plugins return either a str or a pathlib.Path from synthesize().
 AudioPath = Union[str, "os.PathLike[str]"]
@@ -91,12 +91,18 @@ def _read_samples(wav_path: AudioPath) -> Tuple[array.array, int]:
         Tuple of (samples, source_sample_rate). Multi-channel input is
         downmixed by averaging, 8-bit input is scaled up to 16-bit.
     """
+    # Plugins may emit non-WAV audio (e.g. an mp3-only engine); transcode first.
     # wave.open() only opens str paths; anything else it treats as a file object
-    with wave.open(os.fspath(wav_path), "rb") as wf:
-        channels = wf.getnchannels()
-        width = wf.getsampwidth()
-        src_rate = wf.getframerate()
-        frames = wf.readframes(wf.getnframes())
+    src_path, is_temp = _ensure_wav(os.fspath(wav_path))
+    try:
+        with wave.open(src_path, "rb") as wf:
+            channels = wf.getnchannels()
+            width = wf.getsampwidth()
+            src_rate = wf.getframerate()
+            frames = wf.readframes(wf.getnframes())
+    finally:
+        if is_temp:
+            os.remove(src_path)
 
     if width == 1:
         # 8-bit WAV samples are unsigned

--- a/test/unittests/test_audio_utils.py
+++ b/test/unittests/test_audio_utils.py
@@ -2,6 +2,7 @@
 """Unit tests for ovos_tts_server.audio_utils.convert_audio."""
 import builtins
 import io
+import os
 import sys
 import tempfile
 import wave
@@ -91,3 +92,94 @@ class TestConvertAudio:
             assert data == b"FAKEDATA"
             assert captured["path"] == wav_path
             assert captured["format"] == ("mp3" if fmt == "mp3" else fmt)
+
+
+def _write_non_riff(suffix: str = ".mp3") -> str:
+    """Write a small file whose header is not a RIFF WAV."""
+    tmp = tempfile.NamedTemporaryFile(suffix=suffix, delete=False)
+    tmp.write(b"ID3\x03\x00\x00\x00\x00\x00\x00not-a-wav-payload")
+    tmp.close()
+    return tmp.name
+
+
+class TestEnsureWav:
+    def test_wav_returns_same_path_untouched(self, wav_path):
+        """A real WAV is passed through without transcoding or temp files."""
+        from ovos_tts_server.audio_utils import _ensure_wav
+
+        out_path, is_temp = _ensure_wav(wav_path)
+        assert out_path == wav_path
+        assert is_temp is False
+
+    def test_non_wav_is_transcoded_to_temp_wav(self, monkeypatch):
+        """Non-WAV plugin output is transcoded to a fresh temp WAV via pydub."""
+        from ovos_tts_server import audio_utils
+
+        src = _write_non_riff()
+        captured = {}
+
+        class FakeAudio:
+            @classmethod
+            def from_file(cls, path):
+                captured["path"] = path
+                return cls()
+
+            def export(self, out, format):
+                captured["format"] = format
+                with wave.open(out, "w") as wf:
+                    wf.setnchannels(1)
+                    wf.setsampwidth(2)
+                    wf.setframerate(16000)
+                    wf.writeframes(b"\x00\x00" * 10)
+
+        fake_pydub = type(sys)("pydub")
+        fake_pydub.AudioSegment = FakeAudio
+        monkeypatch.setitem(sys.modules, "pydub", fake_pydub)
+
+        out_path, is_temp = audio_utils._ensure_wav(src)
+        try:
+            assert is_temp is True
+            assert out_path != src
+            assert captured["path"] == src
+            assert captured["format"] == "wav"
+            with open(out_path, "rb") as f:
+                assert f.read().startswith(b"RIFF")
+        finally:
+            os.remove(out_path)
+            os.remove(src)
+
+    def test_convert_audio_handles_non_wav_source(self, monkeypatch):
+        """convert_audio no longer raises on mp3-emitting plugin output."""
+        from ovos_tts_server import audio_utils
+
+        src = _write_non_riff()
+
+        class FakeAudio:
+            @classmethod
+            def from_file(cls, path):
+                return cls()
+
+            @classmethod
+            def from_wav(cls, path):
+                return cls()
+
+            def export(self, out, format):
+                if format == "wav":
+                    with wave.open(out, "w") as wf:
+                        wf.setnchannels(1)
+                        wf.setsampwidth(2)
+                        wf.setframerate(16000)
+                        wf.writeframes(b"\x00\x00" * 10)
+                else:
+                    out.write(b"MP3DATA")
+
+        fake_pydub = type(sys)("pydub")
+        fake_pydub.AudioSegment = FakeAudio
+        monkeypatch.setitem(sys.modules, "pydub", fake_pydub)
+
+        try:
+            data, mime = audio_utils.convert_audio(src, "mp3")
+            assert mime == "audio/mpeg"
+            assert data == b"MP3DATA"
+        finally:
+            os.remove(src)

--- a/test/unittests/test_compat_routers.py
+++ b/test/unittests/test_compat_routers.py
@@ -392,3 +392,61 @@ class TestPlayHTRouter:
             assert "http_streaming_url" in body[model]
             assert "stream" in body[model]["http_streaming_url"]
             assert "websocket_url" in body[model]
+
+
+class TestElevenLabsPcmNonWavSource:
+    """The PCM output path must transcode non-WAV plugin output before decoding."""
+
+    def _write_non_riff(self) -> str:
+        tmp = tempfile.NamedTemporaryFile(suffix=".mp3", delete=False)
+        tmp.write(b"ID3\x03\x00\x00\x00\x00\x00\x00not-a-wav-payload")
+        tmp.close()
+        return tmp.name
+
+    def _fake_pydub(self):
+        import sys as _sys
+
+        class FakeAudio:
+            @classmethod
+            def from_file(cls, path):
+                return cls()
+
+            def export(self, out, format):
+                with wave.open(out, "w") as wf:
+                    wf.setnchannels(1)
+                    wf.setsampwidth(2)
+                    wf.setframerate(16000)
+                    wf.writeframes(b"\x00\x01" * 1600)
+
+        mod = type(_sys)("pydub")
+        mod.AudioSegment = FakeAudio
+        return mod
+
+    def test_pcm_output_handles_mp3_source(self, monkeypatch):
+        import sys as _sys
+
+        from ovos_tts_server.routers.elevenlabs import encode_audio
+
+        monkeypatch.setitem(_sys.modules, "pydub", self._fake_pydub())
+        src = self._write_non_riff()
+        try:
+            data, mime = encode_audio(src, "pcm_24000")
+            assert mime == "audio/pcm"
+            assert isinstance(data, (bytes, bytearray))
+            assert len(data) > 0
+        finally:
+            os.remove(src)
+
+    def test_read_samples_handles_mp3_source(self, monkeypatch):
+        import sys as _sys
+
+        from ovos_tts_server.routers.elevenlabs import _read_samples
+
+        monkeypatch.setitem(_sys.modules, "pydub", self._fake_pydub())
+        src = self._write_non_riff()
+        try:
+            samples, rate = _read_samples(src)
+            assert rate == 16000
+            assert len(samples) == 1600
+        finally:
+            os.remove(src)


### PR DESCRIPTION
## Problem

The compat routers (ElevenLabs and friends) assume the loaded TTS plugin emits WAV. `convert_audio` reads the synthesized file with a raw-bytes WAV passthrough and with `pydub.AudioSegment.from_wav()`, both of which require a RIFF WAV.

Some OVOS TTS plugins declare a non-WAV `audio_ext` — for example `ovos-tts-plugin-edge-tts` sets `audio_ext="mp3"` because edge_tts only emits mp3. For those plugins:

- the ElevenLabs `POST /v1/text-to-speech/{voice_id}` endpoint raises `wave.Error: file does not start with RIFF id` and returns HTTP 500 for any non-passthrough format, and
- the `wav`/`pcm` passthrough returns mp3 bytes mislabeled as `audio/wav`.

WAV-emitting plugins (e.g. phoonnx) work; any mp3-emitting plugin fails.

## Fix

Add `_ensure_wav(path)` in `audio_utils`. It returns the path unchanged when `wave.open` succeeds, otherwise transcodes the plugin output to a temporary WAV and returns that. `convert_audio` calls it first, so every format path (and every compat router that goes through `convert_audio`) works regardless of the plugin's native audio format. The temporary WAV is removed after use.

Transcoding reuses `pydub` (already the repo's optional `audio` dependency). When pydub is not installed it falls back to `ffmpeg -y -loglevel error -i <in> <out.wav>` via subprocess.

## Runtime requirement

Decoding non-WAV plugin output requires a working audio backend — `pydub` (the `audio` extra) plus `ffmpeg`, or `ffmpeg` on `PATH` for the subprocess fallback. WAV-emitting plugins are unaffected and need neither.

## Tests

Extends `test/unittests/test_audio_utils.py`: a real WAV passes through untouched, a non-RIFF file is transcoded to a temp WAV, and `convert_audio` no longer raises on non-WAV source. Existing tests are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)