### PR TITLE
feat: dialog and tts transformer pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,30 @@ The plugin is configured exactly as it would be inside the assistant — through
 
 See [docs/configuration.md](docs/configuration.md) for how voice and language flow from a request to the plugin.
 
+### Transformer pipelines
+
+The server can run OVOS transformer plugins around synthesis, on every
+endpoint (native, vendor-compat, websocket, MCP/UTCP): **dialog
+transformers** rewrite the text before synthesis and **tts transformers**
+post-process the audio. Opt-in via the standard mycroft.conf sections:
+
+```json
+{
+  "dialog_transformers": {
+    "ovos-dialog-transformer-openai-plugin": {"rewrite_prompt": "reply in a cheerful tone"}
+  },
+  "tts_transformers": {
+    "ovos-tts-transformer-sox-plugin": {"pitch": 300}
+  }
+}
+```
+
+Enabling a dialog transformer server-side means the server deliberately
+synthesizes **different text than the client sent** — that's the tool for
+setting a tone/persona globally across every device using this server. See
+[docs/transformers.md](docs/transformers.md) for when to use server-side vs
+device-side transformers and how to avoid double-processing.
+
 ## HTTP API
 
 The native OVOS endpoints:
@@ -153,6 +177,7 @@ pytest test/ -v
 
 - [API compatibility reference](docs/api-compatibility.md) — every vendor prefix, endpoint, and SDK snippet
 - [Voice & language configuration](docs/configuration.md) — how requests map to the plugin
+- [Transformer pipelines](docs/transformers.md) — dialog/tts transformer plugins around synthesis
 - [Audio format conversion](docs/audio-formats.md) — `convert_audio()` and the `[audio]` extra
 - [Architecture overview](docs/index.md) — classes, entry points, request flow
 

--- a/docs/transformers.md
+++ b/docs/transformers.md
@@ -1,0 +1,53 @@
+# Transformer Pipelines
+
+The server can run OVOS transformer plugins around synthesis. Both hooks
+live in the engine wrapper, so **every** surface gets them: native
+endpoints, all vendor-compat routers, the websocket streaming routes, MCP
+and UTCP.
+
+- **Dialog transformers** rewrite the utterance *text* before synthesis.
+- **TTS transformers** post-process the synthesized *audio* before it is
+  served. They run on a temp copy — the plugin's audio cache is never
+  mutated, so cache hits are never served pre-transformed audio.
+
+## Configuration
+
+Loading is config-gated and opt-in via the standard mycroft.conf sections;
+with no config the server behaves exactly as before:
+
+```json
+{
+  "dialog_transformers": {
+    "ovos-dialog-transformer-openai-plugin": {"rewrite_prompt": "rewrite the text as if you were explaining it to a 5 year old"}
+  },
+  "tts_transformers": {
+    "ovos-tts-transformer-sox-plugin": {"pitch": 300}
+  }
+}
+```
+
+Chains run in ascending priority order (OVOS-TRANSFORM §4); an explicit
+`"order"` list in a section wins over priorities. See the
+[ovos-plugin-manager transformer docs](https://github.com/OpenVoiceOS/ovos-plugin-manager/blob/dev/docs/transformers.md)
+for the full contract.
+
+## When to use — and the surprise factor
+
+A dialog transformer on the *server* means the server synthesizes
+**different text than the client sent**. From the client's perspective that
+is unexpected — a request for "the CPU is at 95 percent" comes back as
+audio saying something else. Do it on purpose:
+
+- **Global tone/persona**: enable one dialog transformer here and every
+  device, app and vendor-SDK client that synthesizes through this server
+  gets the same voice personality, fleet-wide, with zero client changes.
+- **Global audio post-processing**: a tts transformer here applies the same
+  effect (pitch, speed, loudness normalization) to every response.
+
+If instead the effect should be **per-device** (one speaker needs a boost,
+one room needs a different pitch), run the transformer on that device
+(ovos-audio or a HiveMind satellite), not here — and never enable the same
+plugin on both sides, or it is applied twice.
+
+Note for the caching-inclined: dialog transformation happens *before* the
+TTS cache, so the cache keys on the transformed text and stays consistent.

--- a/ovos_tts_server/__init__.py
+++ b/ovos_tts_server/__init__.py
@@ -1,7 +1,12 @@
+import os
+import shutil
+import tempfile
 from typing import Optional, Tuple
 from fastapi import FastAPI, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
+from ovos_plugin_manager.transformer_services import (DialogTransformersService,
+                                                      TTSTransformersService)
 from ovos_plugin_manager.tts import load_tts_plugin
 from ovos_config import Configuration
 
@@ -32,6 +37,13 @@ class TTSEngineWrapper:
         self.engine.log_timestamps = True
         self.plugin_name = plugin_name
         self.lang = config.get("lang") or Configuration().get("lang") or "mul"
+        # transformer pipelines: config-gated and opt-in, a plugin only
+        # loads if named in the mycroft.conf "dialog_transformers" /
+        # "tts_transformers" sections
+        self.dialog_transformers = DialogTransformersService(
+            config=Configuration().get("dialog_transformers") or {})
+        self.tts_transformers = TTSTransformersService(
+            config=Configuration().get("tts_transformers") or {})
 
     @property
     def langs(self):
@@ -64,9 +76,29 @@ class TTSEngineWrapper:
         Returns:
         	tuple (str, Optional[str]): `(audio_path, phonemes)` where `audio_path` is the file path to the generated audio and `phonemes` is the phoneme data produced by the engine, or `None` if not available.
         """
+        if self.dialog_transformers.plugins:
+            utterance, _ = self.dialog_transformers.transform(
+                utterance, {"lang": kwargs.get("lang") or self.lang})
         utterance = self.engine.validate_ssml(utterance)
         audio, phonemes = self.engine.synth(utterance, **kwargs)
-        return audio.path, phonemes
+        audio_path = audio.path
+        if self.tts_transformers.plugins:
+            audio_path = self._apply_tts_transformers(audio_path)
+        return audio_path, phonemes
+
+    def _apply_tts_transformers(self, audio_path: str) -> str:
+        """Run the TTS transformer chain on a copy of the synthesized file.
+
+        The engine returns a path into its cache; transforming a copy keeps
+        cached audio pristine so later requests are not served already
+        transformed (or repeatedly re-transformed) files.
+        """
+        ext = os.path.splitext(audio_path)[1] or ".wav"
+        with tempfile.NamedTemporaryFile(suffix=ext, delete=False) as f:
+            tmp_path = f.name
+        shutil.copy(audio_path, tmp_path)
+        transformed, _ = self.tts_transformers.transform(tmp_path)
+        return transformed
 
 
 def create_app(tts_engine: TTSEngineWrapper) -> FastAPI:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ keywords = [
     "OpenVoiceOS",
 ]
 dependencies = [
-    "ovos-plugin-manager>=2.1.0,<3.0.0",
+    "ovos-plugin-manager>=2.10.0a1,<3.0.0",
     "fastapi~=0.115",
     "uvicorn~=0.34",
     # uvicorn serves WebSockets only when a ws implementation is importable;

--- a/test/unittests/test_engine_wrapper.py
+++ b/test/unittests/test_engine_wrapper.py
@@ -30,8 +30,16 @@ def _patched_wrapper(plugin_name="fake-tts", cache=False, config_overrides=None,
     cfg = MagicMock()
     cfg.get.side_effect = lambda k, d=None: cfg_dict.get(k, d)
 
+    fake_dialog_svc = MagicMock()
+    fake_dialog_svc.plugins = []
+    fake_tts_svc = MagicMock()
+    fake_tts_svc.plugins = []
     with patch("ovos_tts_server.load_tts_plugin", return_value=fake_plugin_cls), \
-         patch("ovos_tts_server.Configuration", return_value=cfg):
+         patch("ovos_tts_server.Configuration", return_value=cfg), \
+         patch("ovos_tts_server.DialogTransformersService",
+               return_value=fake_dialog_svc), \
+         patch("ovos_tts_server.TTSTransformersService",
+               return_value=fake_tts_svc):
         wrapper = TTSEngineWrapper(plugin_name=plugin_name, cache=cache, lang=lang)
     return wrapper, fake_engine, fake_plugin_cls
 
@@ -141,3 +149,57 @@ class TestStartTTSServer:
             app, engine = start_tts_server("foo", cache=False)
             assert app is not None
             assert isinstance(engine, TTSEngineWrapper)
+
+
+# ---------------------------------------------------------------------------
+# Transformer pipelines
+# ---------------------------------------------------------------------------
+
+class TestTransformerPipelines:
+    def test_no_transformers_by_default(self):
+        """With empty config sections no transformer runs and synth output
+        is returned untouched."""
+        wrapper, engine, _ = _patched_wrapper()
+        path, phonemes = wrapper.synthesize("hello")
+        assert path == "/tmp/fake.wav"
+        wrapper.dialog_transformers.transform.assert_not_called()
+        wrapper.tts_transformers.transform.assert_not_called()
+
+    def test_dialog_transformer_rewrites_utterance_before_synth(self):
+        wrapper, engine, _ = _patched_wrapper()
+        wrapper.dialog_transformers.plugins = ["fake-plugin"]
+        wrapper.dialog_transformers.transform.return_value = ("rewritten", {})
+        wrapper.synthesize("hello", lang="en-us")
+        wrapper.dialog_transformers.transform.assert_called_once_with(
+            "hello", {"lang": "en-us"})
+        engine.synth.assert_called_once()
+        assert engine.synth.call_args[0][0] == "rewritten"
+
+    def test_tts_transformer_runs_on_a_copy(self, tmp_path):
+        """The synthesized (cached) file must never be handed to the
+        transformer chain directly."""
+        cached = tmp_path / "cached.wav"
+        cached.write_bytes(b"ORIGINAL")
+
+        wrapper, engine, _ = _patched_wrapper()
+        audio = MagicMock()
+        audio.path = str(cached)
+        engine.synth.return_value = (audio, None)
+
+        seen = {}
+
+        def fake_transform(path, context=None):
+            seen["path"] = path
+            with open(path, "wb") as f:
+                f.write(b"TRANSFORMED")
+            return path, context or {}
+
+        wrapper.tts_transformers.plugins = ["fake-plugin"]
+        wrapper.tts_transformers.transform.side_effect = fake_transform
+
+        out_path, _ = wrapper.synthesize("hello")
+        assert seen["path"] != str(cached)
+        assert out_path == seen["path"]
+        assert cached.read_bytes() == b"ORIGINAL"
+        with open(out_path, "rb") as f:
+            assert f.read() == b"TRANSFORMED"


### PR DESCRIPTION
## What

Adds OVOS transformer pipeline support to the TTS server, using the canonical runner services from OpenVoiceOS/ovos-plugin-manager#410:

- **Dialog transformers** rewrite the utterance text before `engine.synth()`.
- **TTS transformers** post-process the synthesized audio before it is served.

Both hooks live in `TTSEngineWrapper.synthesize()` — the single choke-point every native endpoint, vendor-compat router, websocket streaming route, MCP and UTCP surface flows through — so all of them get the pipelines with no per-router changes.

## Behavior

- Config-gated and opt-in via the standard `dialog_transformers` / `tts_transformers` mycroft.conf sections; with no config the server behaves exactly as before.
- Chains follow OVOS-TRANSFORM §4 (ascending priority, explicit `"order"` list supported).
- TTS transformers run on a temp copy of the synthesized file, so the TTS plugin's audio cache is never mutated and later cache hits are not served pre-transformed audio.
- Dialog transformation happens before synthesis, so the plugin cache keys on the transformed text and stays consistent.

## Testing

New unit tests cover: default-off behavior, dialog rewrite reaching `synth()`, and cache-copy isolation for tts transformers. Existing wrapper tests were made hermetic against machine-local transformer config.

Example config:
```json
{
  "tts_transformers": {
    "ovos-tts-transformer-sox-plugin": {"pitch": 300}
  }
}
```

## Depends on

- OpenVoiceOS/ovos-plugin-manager#410 — this PR pins `ovos-plugin-manager>=2.10.0a1`. CI stays red until that alpha is on PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)