### PR TITLE
docs: rewrite README in Simplified Technical English

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@
 [![Python](https://img.shields.io/pypi/pyversions/ovos-tts-server)](https://pypi.org/project/ovos-tts-server/)
 [![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE.md)
 
-Turn **any** [OVOS TTS plugin](https://github.com/OpenVoiceOS) into a microservice — a small, stateless [FastAPI](https://fastapi.tiangolo.com/) app that exposes text-to-speech over HTTP.
+`ovos-tts-server` turns any [OVOS TTS plugin](https://github.com/OpenVoiceOS) into a microservice. It is a small, stateless [FastAPI](https://fastapi.tiangolo.com/) app that exposes text-to-speech over HTTP.
 
-- 🔌 **Plugin-agnostic** — serve Piper, Coqui, Azure, or any OVOS TTS plugin behind one consistent HTTP API.
-- 🧩 **Drop-in cloud-API compatibility** — speak the ElevenLabs, OpenAI, Coqui, Google, Amazon Polly, Azure, MaryTTS, Cartesia, Deepgram Aura, and PlayHT APIs so existing clients and SDKs work unmodified (see [API compatibility](docs/api-compatibility.md)).
-- 🪶 **Stateless & tiny** — each request loads nothing extra; ideal for containers and horizontal scaling.
-- 🎛️ **Format conversion** — return WAV out of the box, or mp3/ogg/flac/… with the optional `[audio]` extra.
+- **Plugin-agnostic.** Serve Piper, Coqui, Azure, or any OVOS TTS plugin behind one HTTP API.
+- **Cloud-API compatibility.** The server also speaks the ElevenLabs, OpenAI, Coqui, Google, Amazon Polly, Azure, MaryTTS, Cartesia, Deepgram Aura, and PlayHT APIs, so existing clients and SDKs work unmodified. See [API compatibility](docs/api-compatibility.md).
+- **Stateless.** Each request loads nothing extra. This suits containers and horizontal scaling.
+- **Format conversion.** The server returns WAV by default, or mp3/ogg/flac/... with the optional `[audio]` extra.
 
 ---
 
@@ -18,11 +18,11 @@ Turn **any** [OVOS TTS plugin](https://github.com/OpenVoiceOS) into a microservi
 ```bash
 pip install ovos-tts-server
 
-# Optional: enable non-WAV output (mp3, ogg, flac, …) via pydub
+# Optional: enable non-WAV output (mp3, ogg, flac, ...) via pydub
 pip install "ovos-tts-server[audio]"
 ```
 
-You also need at least one TTS plugin, e.g. [Piper](https://github.com/OpenVoiceOS/ovos-tts-plugin-piper):
+You also need at least one TTS plugin, for example [Piper](https://github.com/OpenVoiceOS/ovos-tts-plugin-piper):
 
 ```bash
 pip install ovos-tts-plugin-piper
@@ -46,7 +46,7 @@ ovos-tts-server [-h] [--engine ENGINE] [--port PORT] [--host HOST] [--cache] [--
 
 | Option | Default | Description |
 | :--- | :--- | :--- |
-| `--engine ENGINE` | — | TTS plugin to load (e.g. `ovos-tts-plugin-piper`) |
+| `--engine ENGINE` | none | TTS plugin to load (for example `ovos-tts-plugin-piper`) |
 | `--port PORT` | `9666` | Port to bind |
 | `--host HOST` | `0.0.0.0` | Host/interface to bind |
 | `--cache` | off | Persist every synth to disk (cache across requests) |
@@ -54,7 +54,7 @@ ovos-tts-server [-h] [--engine ENGINE] [--port PORT] [--host HOST] [--cache] [--
 
 ## Configuration
 
-The plugin is configured exactly as it would be inside the assistant — through `mycroft.conf`:
+The plugin is configured exactly as it would be inside the assistant, through `mycroft.conf`:
 
 ```json
 {
@@ -71,10 +71,7 @@ See [docs/configuration.md](docs/configuration.md) for how voice and language fl
 
 ### Transformer pipelines
 
-The server can run OVOS transformer plugins around synthesis, on every
-endpoint (native, vendor-compat, websocket, MCP/UTCP): **dialog
-transformers** rewrite the text before synthesis and **tts transformers**
-post-process the audio. Opt-in via the standard mycroft.conf sections:
+The server can run OVOS transformer plugins around synthesis, on every endpoint (native, vendor-compat, websocket, MCP/UTCP). **Dialog transformers** rewrite the text before synthesis, and **tts transformers** post-process the audio. Enable them with the standard mycroft.conf sections:
 
 ```json
 {
@@ -87,11 +84,7 @@ post-process the audio. Opt-in via the standard mycroft.conf sections:
 }
 ```
 
-Enabling a dialog transformer server-side means the server deliberately
-synthesizes **different text than the client sent** — that's the tool for
-setting a tone/persona globally across every device using this server. See
-[docs/transformers.md](docs/transformers.md) for when to use server-side vs
-device-side transformers and how to avoid double-processing.
+Enabling a dialog transformer server-side means the server deliberately synthesizes different text than the client sent. Use it to set a tone or persona globally, across every device using this server. See [docs/transformers.md](docs/transformers.md) for when to use server-side or device-side transformers, and how to avoid processing the text twice.
 
 ## HTTP API
 
@@ -100,10 +93,10 @@ The native OVOS endpoints:
 | Method | Path | Description |
 | :--- | :--- | :--- |
 | GET | `/status` | Plugin name, supported languages, default voice/model |
-| GET | `/v2/synthesize?utterance=<text>[&lang=…][&voice=…]` | Primary synthesis endpoint — returns a WAV file |
+| GET | `/v2/synthesize?utterance=<text>[&lang=...][&voice=...]` | Primary synthesis endpoint. Returns a WAV file |
 | GET | `/synthesize/<utterance>` | Legacy path-based synthesis endpoint |
 
-Any extra query parameters on the synthesis endpoints are forwarded to the plugin as synthesis options. CORS is enabled for all origins.
+The server forwards any extra query parameter on the synthesis endpoints to the plugin as a synthesis option. CORS is enabled for all origins.
 
 ```bash
 curl http://localhost:9666/status
@@ -112,7 +105,7 @@ curl http://localhost:9666/status
 
 ### Third-party API compatibility
 
-The server can **additionally** expose the same plugin behind drop-in compatibility endpoints for popular cloud TTS APIs. Each vendor lives under its own URL prefix, so every compat layer is active at once with no path collisions. Auth tokens / API keys are accepted and silently ignored — put real auth in a reverse proxy if you need it.
+The server can also expose the same plugin behind drop-in compatibility endpoints for popular cloud TTS APIs. Each vendor lives under its own URL prefix, so every compat layer stays active at once with no path collisions. The server accepts auth tokens and API keys but ignores them silently; put real auth in a reverse proxy if you need it.
 
 | Vendor | Prefix | Key endpoint |
 | :--- | :--- | :--- |
@@ -122,14 +115,14 @@ The server can **additionally** expose the same plugin behind drop-in compatibil
 | Google Cloud TTS | `/google-tts` | `POST /v1/text:synthesize` |
 | Amazon Polly | `/amazon-polly` | `POST /v1/speech` |
 | Azure TTS | `/azure-tts` | `POST /cognitiveservices/v1` |
-| MaryTTS | `/marytts` | `GET/POST /process` (+ root aliases) |
+| MaryTTS | `/marytts` | `GET/POST /process` (plus root aliases) |
 | Cartesia | `/cartesia` | `POST /tts/bytes` |
-| Deepgram Aura | `/deepgram` | `POST /v1/speak?model=…` |
-| PlayHT | `/playht` | `POST /api/v2/tts/stream` (+ `pyht` SDK auth) |
+| Deepgram Aura | `/deepgram` | `POST /v1/speak?model=...` |
+| PlayHT | `/playht` | `POST /api/v2/tts/stream` (plus `pyht` SDK auth) |
 
-> **Kokoro / kokoro-fastapi** clients are OpenAI-compatible and need no dedicated prefix — point them at `/openai/v1/audio/speech`.
+**Kokoro / kokoro-fastapi** clients are OpenAI-compatible and need no dedicated prefix. Point them at `/openai/v1/audio/speech`.
 
-Most official SDKs accept a custom base URL; point them at `http://<host>:9666/<prefix>` and they work unmodified. See **[docs/api-compatibility.md](docs/api-compatibility.md)** for per-vendor endpoints, parameters, SDK snippets, and curl examples.
+Most official SDKs accept a custom base URL. Point them at `http://<host>:9666/<prefix>` and they work unmodified. See [docs/api-compatibility.md](docs/api-compatibility.md) for per-vendor endpoints, parameters, SDK snippets, and curl examples.
 
 ## Python API
 
@@ -137,7 +130,7 @@ Most official SDKs accept a custom base URL; point them at `http://<host>:9666/<
 from ovos_tts_server import start_tts_server
 
 app, engine = start_tts_server("ovos-tts-plugin-piper", cache=False)
-# `app` is a FastAPI instance — mount it, test it, or run it with uvicorn
+# `app` is a FastAPI instance: mount it, test it, or run it with uvicorn
 ```
 
 `create_app(tts_engine)` is also available if you want to build and inject the `TTSEngineWrapper` yourself.
@@ -160,11 +153,11 @@ docker run -p 8080:9666 my_ovos_tts_plugin
 curl "http://localhost:8080/v2/synthesize?utterance=hello" -o hello.wav
 ```
 
-Each plugin can ship its own Dockerfile in its repository using `ovos-tts-server`.
+Each plugin can ship its own Dockerfile in its repository, using `ovos-tts-server`.
 
 ## Companion plugin
 
-Consume this server from a voice assistant via the [companion TTS plugin](https://github.com/OpenVoiceOS/ovos-tts-server-plugin).
+Consume this server from a voice assistant with the [companion TTS plugin](https://github.com/OpenVoiceOS/ovos-tts-server-plugin).
 
 ## Development
 
@@ -175,24 +168,21 @@ pytest test/ -v
 
 ## Documentation
 
-- [API compatibility reference](docs/api-compatibility.md) — every vendor prefix, endpoint, and SDK snippet
-- [Voice & language configuration](docs/configuration.md) — how requests map to the plugin
-- [Transformer pipelines](docs/transformers.md) — dialog/tts transformer plugins around synthesis
-- [Audio format conversion](docs/audio-formats.md) — `convert_audio()` and the `[audio]` extra
-- [Architecture overview](docs/index.md) — classes, entry points, request flow
+- [API compatibility reference](docs/api-compatibility.md): every vendor prefix, endpoint, and SDK snippet
+- [Voice & language configuration](docs/configuration.md): how requests map to the plugin
+- [Transformer pipelines](docs/transformers.md): dialog/tts transformer plugins around synthesis
+- [Audio format conversion](docs/audio-formats.md): `convert_audio()` and the `[audio]` extra
+- [Architecture overview](docs/index.md): classes, entry points, request flow
 
 ---
 
-## Agent Integration
+## Agent integration
 
-### UTCP — Universal Tool Calling Protocol
+### UTCP: Universal Tool Calling Protocol
 
-The server exposes a **UTCP manual** at `GET /utcp`.  Any UTCP-aware agent
-(e.g. [ovos-tool-adapters](https://github.com/OpenVoiceOS/ovos-tool-adapters)
-`UTCPToolBox`) can point at this URL and auto-discover every synthesis endpoint
-without additional configuration.
+The server exposes a UTCP manual at `GET /utcp`. Any UTCP-aware agent, for example [ovos-tool-adapters](https://github.com/OpenVoiceOS/ovos-tool-adapters)' `UTCPToolBox`, can point at this URL and auto-discover every synthesis endpoint without extra configuration.
 
-No extra dependencies are needed — `GET /utcp` is always available.
+`GET /utcp` needs no extra dependencies. It is always available.
 
 **Example response (abbreviated):**
 ```json
@@ -239,11 +229,9 @@ No extra dependencies are needed — `GET /utcp` is always available.
 
 ---
 
-### MCP — Model Context Protocol
+### MCP: Model Context Protocol
 
-The server can optionally expose a **FastMCP server** mounted at `/mcp`,
-providing a `synthesize` tool callable by any MCP-compatible agent (Claude
-Desktop, Claude Code, etc.).
+The server can optionally expose a FastMCP server mounted at `/mcp`, providing a `synthesize` tool callable by any MCP-compatible agent (Claude Desktop, Claude Code, and others).
 
 **Install the extra:**
 ```bash
@@ -261,8 +249,7 @@ from ovos_tts_server import start_tts_server
 app, engine = start_tts_server("ovos-tts-plugin-piper", enable_mcp=True)
 ```
 
-The MCP server uses **streamable HTTP transport** (SSE-compatible) and is
-mounted alongside the existing FastAPI app — no separate process needed.
+The MCP server uses streamable HTTP transport (SSE-compatible) and mounts alongside the existing FastAPI app. No separate process is needed.
 
 **Claude Desktop `claude_desktop_config.json` example:**
 ```json
@@ -282,7 +269,7 @@ mounted alongside the existing FastAPI app — no separate process needed.
 |-----------|--------|----------|--------------------------------------|
 | `text`    | string | yes      | Text to synthesize                   |
 | `voice`   | string | no       | Voice/speaker identifier             |
-| `lang`    | string | no       | BCP-47 language code (e.g. `en-us`)  |
+| `lang`    | string | no       | BCP-47 language code (for example `en-us`) |
 
 Returns a JSON object:
 ```json
@@ -298,8 +285,7 @@ Returns a JSON object:
 
 ## Credits
 
-Developed by [TigreGótico](https://tigregotico.pt) for
-[OpenVoiceOS](https://openvoiceos.org).
+Developed by [TigreGótico](https://tigregotico.pt) for [OpenVoiceOS](https://openvoiceos.org).
 
 [![NGI0 Commons Fund](./ngi.png)](https://nlnet.nl/project/OpenVoiceOS)
 

--- a/docs/api-compatibility.md
+++ b/docs/api-compatibility.md
@@ -2,11 +2,10 @@
 
 `ovos-tts-server` exposes its underlying OVOS TTS plugin behind drop-in
 compatibility endpoints for popular cloud TTS APIs. Each vendor lives under its
-own URL prefix, so every compat layer is active simultaneously with no path
-collisions — point a client at the matching prefix and it works unmodified.
+own URL prefix, so every compat layer is active at once with no path
+collisions. Point a client at the matching prefix and it works unmodified.
 
-All routers accept any auth token / API key from the client and **silently
-ignore it** — authentication is the responsibility of your reverse proxy.
+All routers accept any auth token or API key from the client and ignore it silently. Authentication is the responsibility of your reverse proxy.
 
 Audio format conversion is provided by `ovos_tts_server.audio_utils.convert_audio()`.
 Install the `[audio]` extra (`pip install "ovos-tts-server[audio]"`) to enable
@@ -25,11 +24,11 @@ non-WAV outputs via `pydub`; without it, non-WAV requests fall back to WAV. See
 | [Azure TTS](#azure-tts-azure-tts) | `/azure-tts` | `POST /cognitiveservices/v1` | binary audio |
 | [MaryTTS](#marytts-marytts) | `/marytts` | `GET/POST /process`, `GET /voices`, `GET /locales` (+ root aliases) | binary WAV / text |
 | [Cartesia](#cartesia-cartesia) | `/cartesia` | `POST /tts/bytes` | binary audio |
-| [Deepgram Aura](#deepgram-aura-deepgram) | `/deepgram` | `POST /v1/speak?model=…` | binary audio |
+| [Deepgram Aura](#deepgram-aura-deepgram) | `/deepgram` | `POST /v1/speak?model=...` | binary audio |
 | [PlayHT](#playht-playht) | `/playht` | `POST /api/v2/tts/stream`, `POST /api/v4/sdk-auth` | binary audio |
 
 > **Kokoro / kokoro-fastapi** is OpenAI-compatible and needs no dedicated
-> router — point any OpenAI-compatible client at the `/openai` prefix
+> router, point any OpenAI-compatible client at the `/openai` prefix
 > (`/openai/v1/audio/speech`).
 
 Examples below assume the server runs at `http://localhost:9666`.
@@ -52,20 +51,20 @@ Examples below assume the server runs at `http://localhost:9666`.
 
 The `voice_id` may span several path segments, so voices named after a
 HuggingFace repo id (`OpenVoiceOS/phoonnx_ar_dii_espeak`) can be addressed
-directly — pass the id exactly as `GET /v1/voices` reports it.
+directly. Pass the id exactly as `GET /v1/voices` reports it.
 
-**Synthesis request** — path `voice_id` (use `default` for the plugin default),
+**Synthesis request:** path `voice_id` (use `default` for the plugin default),
 query `output_format` (default `mp3_44100_128`), JSON body:
 
 | Field | Type | Notes |
 | :--- | :--- | :--- |
 | `text` | str (required) | Text to synthesize |
 | `model_id` | str | Accepted, not forwarded |
-| `voice_settings` | object | `stability`, `similarity_boost`, `style`, `use_speaker_boost` — accepted, not forwarded |
+| `voice_settings` | object | `stability`, `similarity_boost`, `style`, `use_speaker_boost`, accepted, not forwarded |
 
 `output_format` selects both container and sample rate: `pcm_*` → headerless
 mono 16-bit little-endian PCM resampled to the requested rate (`pcm_16000`,
-`pcm_22050`, `pcm_24000`, `pcm_44100`, …), `ulaw_8000` → G.711 mu-law,
+`pcm_22050`, `pcm_24000`, `pcm_44100`, ...), `ulaw_8000` → G.711 mu-law,
 `opus_*` → Ogg, otherwise the leading token (`mp3_44100_128` → `mp3`).
 Compressed containers fall back to WAV if pydub is absent.
 
@@ -100,17 +99,17 @@ new ElevenLabsClient({ apiKey: "ignored", baseUrl: "http://localhost:9666/eleven
 
 Registered by default, alongside the HTTP endpoints. Query parameters:
 `output_format` (default `mp3_44100_128`, parsed as above), `language_code`
-(→ `lang=`); other ElevenLabs options (`model_id`, `inactivity_timeout`, …) are
+(→ `lang=`); other ElevenLabs options (`model_id`, `inactivity_timeout`, ...) are
 accepted and ignored. Auth is the `xi-api-key` header or an `xi_api_key` field
-in the first message — both accepted, ignored.
+in the first message, both accepted, ignored.
 
 Client → server (JSON text frames):
 
-1. `{"text": " ", "voice_settings": {...}, "generation_config": {...}}` — begin
+1. `{"text": " ", "voice_settings": {...}, "generation_config": {...}}`, begin
    the stream.
-2. `{"text": "hello world "}` — content, repeated; text accumulates.
-3. `{"flush": true}` — generate the buffered text immediately.
-4. `{"text": ""}` — end of stream: the buffer is generated and the socket closes.
+2. `{"text": "hello world "}`, content, repeated; text accumulates.
+3. `{"flush": true}`, generate the buffered text immediately.
+4. `{"text": ""}`, end of stream: the buffer is generated and the socket closes.
 
 Server → client (JSON text frames):
 
@@ -125,8 +124,8 @@ no character timings.
 **Point the SDK at this server:** `client.text_to_speech.convert_realtime()` uses
 this endpoint. Its realtime client derives the WebSocket URL from `base_url=` but
 forces the `wss` scheme, so it cannot reach a plaintext server. Either put a TLS
-terminator in front of ovos-tts-server — then `base_url="https://…"` works
-untouched — or keep `ws` for `http` base URLs:
+terminator in front of ovos-tts-server (then `base_url="https://..."` works
+untouched), or keep `ws` for `http` base URLs:
 
 ```python
 import urllib.parse
@@ -168,17 +167,17 @@ with a `ws://` base) need no patching.
 | :--- | :--- | :--- |
 | POST | `/openai/v1/audio/speech` | Synthesize speech |
 
-**Auth:** `Authorization: Bearer …` header (accepted, ignored).
+**Auth:** `Authorization: Bearer ...` header (accepted, ignored).
 
 JSON body:
 
 | Field | Type | Notes |
 | :--- | :--- | :--- |
 | `input` | str (required) | Text to synthesize (≤ 4096 chars) |
-| `model` | str | Default `tts-1`; accepted, not forwarded |
-| `voice` | str | Default `alloy`; accepted, not forwarded |
+| `model` | str | Default `tts-1`, accepted, not forwarded |
+| `voice` | str | Default `alloy`, accepted, not forwarded |
 | `response_format` | str | Default `mp3`; maps to the output container |
-| `speed` | float | `0.25`–`4.0`; accepted, not forwarded |
+| `speed` | float | `0.25`–`4.0`, accepted, not forwarded |
 
 ```bash
 curl -X POST -H "Authorization: Bearer sk-ignored" -H "Content-Type: application/json" \
@@ -236,7 +235,7 @@ JSON body (Google `SynthesizeSpeech` shape):
 | Field | Notes |
 | :--- | :--- |
 | `input.text` / `input.ssml` | Text or SSML to synthesize (`ssml` wins) |
-| `voice.languageCode` | Default `en-US`; mapped to `lang=` |
+| `voice.languageCode` | Default `en-US`, mapped to `lang=` |
 | `voice.name` | Mapped to `voice=` |
 | `voice.ssmlGender` | Accepted, not forwarded |
 | `audioConfig.audioEncoding` | `MP3`→mp3, `LINEAR16`→wav, `OGG_OPUS`→ogg, `MULAW`/`ALAW`→wav |
@@ -278,10 +277,10 @@ JSON body (Polly `SynthesizeSpeech` shape):
 | Field | Type | Notes |
 | :--- | :--- | :--- |
 | `Text` | str (required) | Text to synthesize |
-| `VoiceId` | str | Default `Joanna`; mapped to `voice=` |
+| `VoiceId` | str | Default `Joanna`, mapped to `voice=` |
 | `OutputFormat` | str | `mp3`→mp3, `ogg_vorbis`→ogg, `pcm`→wav, `json`→mp3 |
 | `LanguageCode` | str | Mapped to `lang=` |
-| `Engine` / `TextType` / `SampleRate` | — | Accepted, not forwarded |
+| `Engine` / `TextType` / `SampleRate` |, | Accepted, not forwarded |
 
 ```bash
 curl -X POST -H "Content-Type: application/json" \
@@ -303,7 +302,7 @@ curl -X POST -H "Content-Type: application/json" \
 **Auth:** `Ocp-Apim-Subscription-Key` header (accepted, ignored).
 
 The request body is raw **SSML**. The router extracts the voice from
-`<voice name="…">` (→ `voice=`) and the language from `xml:lang="…"` (→ `lang=`),
+`<voice name="...">` (→ `voice=`) and the language from `xml:lang="..."` (→ `lang=`),
 then synthesizes the stripped text. The output container is chosen from the
 `X-Microsoft-OutputFormat` header: values containing `mp3` → mp3,
 `pcm`/`wav`/`riff` → wav, `ogg`/`opus` → ogg (default mp3).
@@ -322,7 +321,7 @@ curl -X POST \
 `ovos_tts_server.routers.azure_ws.make_azure_ws_router()` provides a WebSocket
 endpoint (`/azure-tts/cognitiveservices/websocket/v1`) compatible with the Azure
 Speech SDK's `speak_text_async()` / `speak_ssml_async()` calls. It is **not**
-registered by default — include it in your own app if you need it:
+registered by default, include it in your own app if you need it:
 
 ```python
 from ovos_tts_server import start_tts_server
@@ -337,8 +336,8 @@ app.include_router(make_azure_ws_router(engine))
 ## MaryTTS (`/marytts`)
 
 Exposes the classic [MaryTTS](http://mary.dfki.de/) HTTP endpoints so apps that
-already speak MaryTTS — notably **accessibility / assistive tech** and Home
-Assistant's `marytts` integration — can swap in OVOS without code changes. There
+already speak MaryTTS, notably **accessibility / assistive tech** and Home
+Assistant's `marytts` integration, can swap in OVOS without code changes. There
 is no canonical Python SDK; clients hand-roll HTTP.
 
 **Upstream:** [marytts/marytts `MaryHttpServer.java`](https://github.com/marytts/marytts/blob/master/marytts-runtime/src/main/java/marytts/server/http/MaryHttpServer.java) ·
@@ -349,7 +348,7 @@ is no canonical Python SDK; clients hand-roll HTTP.
 | :--- | :--- | :--- |
 | GET | `/marytts/locales` | Newline-separated supported locales |
 | GET | `/marytts/voices` | Newline-separated voices (`name locale gender plugin`) |
-| GET/POST | `/marytts/process` | Synthesize — returns `audio/wav` |
+| GET/POST | `/marytts/process` | Synthesize, returns `audio/wav` |
 
 **Root-path aliases.** MaryTTS predates modern API gateways and is widely used by
 assistive software that hardcodes bare paths, so the same three endpoints are
@@ -376,7 +375,7 @@ curl -G http://localhost:9666/marytts/process \
   -o out.wav
 ```
 
-**Home Assistant** (`configuration.yaml`) — the built-in integration hardcodes
+**Home Assistant** (`configuration.yaml`), the built-in integration hardcodes
 the bare paths, so point it straight at the server; the root-alias router handles
 `/process`, `/voices`, `/locales`:
 
@@ -405,8 +404,8 @@ JSON body:
 | Field | Type | Notes |
 | :--- | :--- | :--- |
 | `transcript` | str (required) | Text to synthesize |
-| `model_id` | str | Default `sonic-english`; accepted, not forwarded |
-| `voice` | object | `id` is mapped to `voice=`; other keys ignored |
+| `model_id` | str | Default `sonic-english`, accepted, not forwarded |
+| `voice` | object | `id` is mapped to `voice=`, other keys ignored |
 | `output_format` | object | `container` selects the output: `wav`, `mp3`, or `raw` (→ PCM/WAV) |
 
 ```bash
@@ -446,10 +445,10 @@ The model is a query parameter and the text is a JSON body:
 
 | Parameter | In | Notes |
 | :--- | :--- | :--- |
-| `model` | query | Default `aura-asteria-en`; mapped to `voice=` |
+| `model` | query | Default `aura-asteria-en`, mapped to `voice=` |
 | `encoding` | query | `linear16`/`mulaw`→wav, `mp3`→mp3, `opus`→ogg, `flac`→flac |
 | `sample_rate` | query | Accepted, not forwarded |
-| `text` | body | Required text to synthesize (`{"text": "…"}`) |
+| `text` | body | Required text to synthesize (`{"text": "..."}`) |
 
 ```bash
 curl -X POST -H "Content-Type: application/json" \
@@ -488,7 +487,7 @@ client.speak.rest.v("1").save("out.wav", {"text": "hello world"},
 | `text` | str **or** list[str] | Text to synthesize (the SDK sends a single-element list) |
 | `voice` | str | Mapped to `voice=` |
 | `output_format` | str | `mp3`/`wav`/`ogg`/`flac`, `raw`→PCM, `mulaw`→wav |
-| `quality` / `speed` / `sample_rate` | — | Accepted, not forwarded |
+| `quality` / `speed` / `sample_rate` |, | Accepted, not forwarded |
 
 ```bash
 curl -X POST -H "Content-Type: application/json" \
@@ -529,8 +528,11 @@ client.close()
 
 ## How parameters reach the plugin
 
-Every router boils its vendor-specific request down to two optional kwargs —
-`voice=` and `lang=` — passed to `engine.synthesize(text, **kwargs)`. Parameters
-a plugin can't act on (speed, pitch, model id, voice settings, …) are accepted
+Every router boils its vendor-specific request down to two optional kwargs,
+`voice=` and `lang=`, passed to `engine.synthesize(text, **kwargs)`. Parameters
+a plugin can't act on (speed, pitch, model id, voice settings, ...) are accepted
 for wire-compatibility and ignored. See [configuration.md](configuration.md) for
 the full flow.
+
+---
+[← Configuration](configuration.md) · [Home](index.md) · [Transformers →](transformers.md)

--- a/docs/audio-formats.md
+++ b/docs/audio-formats.md
@@ -1,9 +1,8 @@
 # Audio Format Conversion
 
-TTS plugins produce WAV. When a client asks for another container (mp3, ogg, …),
-the compat routers convert it with a single helper.
+TTS plugins produce WAV. When a client asks for another container (mp3, ogg, and others), the compat routers convert it with a single helper.
 
-## `convert_audio(wav_path, fmt)` — `ovos_tts_server/audio_utils.py`
+## `convert_audio(wav_path, fmt)`: `ovos_tts_server/audio_utils.py`
 
 ```python
 def convert_audio(wav_path: str, fmt: str) -> Tuple[bytes, str]:
@@ -14,7 +13,7 @@ def convert_audio(wav_path: str, fmt: str) -> Tuple[bytes, str]:
 
 ### Format handling
 
-| `fmt` value | Behaviour | MIME type |
+| `fmt` value | Behavior | MIME type |
 | :--- | :--- | :--- |
 | `"wav"` or `"pcm"` | WAV bytes returned directly (no conversion) | `audio/wav` |
 | `"mp3"` | pydub export as MP3 | `audio/mpeg` |
@@ -23,26 +22,21 @@ def convert_audio(wav_path: str, fmt: str) -> Tuple[bytes, str]:
 | `"aac"` | pydub export as AAC | `audio/aac` |
 | any other | pydub export, MIME `audio/<fmt>` | `audio/<fmt>` |
 
-The `fmt` argument is lower-cased before matching.
+The function lower-cases the `fmt` argument before matching.
 
 ### `pydub` is optional
 
-`pydub` lives in the `[audio]` extra
-(`[project.optional-dependencies] audio = ["pydub"]`). Install it to enable
-non-WAV output:
+`pydub` lives in the `[audio]` extra (`[project.optional-dependencies] audio = ["pydub"]`). Install it to enable non-WAV output:
 
 ```bash
 pip install "ovos-tts-server[audio]"
 ```
 
-When `pydub` is **absent**, any non-WAV request degrades gracefully: the original
-WAV bytes are returned with MIME type `audio/wav`. The request still succeeds —
-the client simply receives WAV instead of the requested container.
+When `pydub` is absent, any non-WAV request degrades gracefully. The server returns the original WAV bytes with MIME type `audio/wav`. The request still succeeds; the client simply receives WAV instead of the requested container.
 
 ### Vendor format strings
 
-Each compat router normalises its vendor's format identifier to one of the
-`fmt` values above before calling `convert_audio()` — for example ElevenLabs'
-`mp3_44100_128` → `mp3`, Google's `LINEAR16` → `wav`, Polly's `ogg_vorbis` →
-`ogg`. Those mappings are documented per vendor in
-[api-compatibility.md](api-compatibility.md).
+Each compat router normalizes its vendor's format identifier to one of the `fmt` values above before calling `convert_audio()`, for example ElevenLabs' `mp3_44100_128` to `mp3`, Google's `LINEAR16` to `wav`, Polly's `ogg_vorbis` to `ogg`. [api-compatibility.md](api-compatibility.md) documents those mappings per vendor.
+
+---
+[← Transformers](transformers.md) · [Home](index.md)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,12 +1,10 @@
 # Voice & Language Configuration
 
-This page explains how a TTS request becomes a call to your plugin, and how
-voices and languages are resolved.
+This page explains how a TTS request becomes a call to your plugin, and how the server resolves voices and languages.
 
 ## Plugin configuration
 
-The plugin is configured exactly as it would be inside an assistant — via
-`mycroft.conf`. The server reads the `tts` section at startup:
+The plugin is configured exactly as it would be inside an assistant, through `mycroft.conf`. The server reads the `tts` section at startup:
 
 ```json
 {
@@ -20,29 +18,19 @@ The plugin is configured exactly as it would be inside an assistant — via
 }
 ```
 
-`TTSEngineWrapper` loads the plugin named by `module` (or the `--engine` flag)
-and passes its config block to the plugin. The `--cache` flag sets
-`persist_cache` so generated audio is kept on disk across requests.
+`TTSEngineWrapper` loads the plugin named by `module` (or the `--engine` flag) and passes its config block to the plugin. The `--cache` flag sets `persist_cache` so the server keeps generated audio on disk across requests.
 
 ## How voice and language flow to the plugin
 
-Each compat router translates its vendor-specific parameters into `voice=` and
-`lang=` keyword arguments, which are forwarded to the plugin:
+Each compat router translates its vendor-specific parameters into `voice=` and `lang=` keyword arguments, which it forwards to the plugin:
 
 ```
 vendor request → router → engine.synthesize(text, voice=..., lang=...) → plugin
 ```
 
-For example: Coqui's `speaker_id`/`language_id`, Google's `voice.name`/
-`voice.languageCode`, Polly's `VoiceId`/`LanguageCode`, and Azure's SSML
-`<voice name=…>` / `xml:lang=…` all collapse to the same two kwargs. Parameters a
-plugin can't act on (speed, pitch, model id, …) are accepted for
-wire-compatibility and ignored. Per-vendor mappings are tabulated in
-[api-compatibility.md](api-compatibility.md).
+For example, Coqui's `speaker_id`/`language_id`, Google's `voice.name`/`voice.languageCode`, Polly's `VoiceId`/`LanguageCode`, and Azure's SSML `<voice name=...>` / `xml:lang=...` all collapse to the same two kwargs. The server accepts parameters a plugin can't act on (speed, pitch, model id, and others) for wire-compatibility and ignores them. [api-compatibility.md](api-compatibility.md) tabulates the per-vendor mappings.
 
-On the native endpoints (`/synthesize/{utterance}`, `/v2/synthesize`), **any**
-extra query parameter is forwarded verbatim to the plugin, so plugin-specific
-options work without a dedicated mapping.
+On the native endpoints (`/synthesize/{utterance}`, `/v2/synthesize`), the server forwards any extra query parameter verbatim to the plugin, so plugin-specific options work without a dedicated mapping.
 
 ## `TTSEngineWrapper.synthesize`
 
@@ -50,24 +38,17 @@ options work without a dedicated mapping.
 TTSEngineWrapper.synthesize(utterance: str, **kwargs) -> Tuple[str, Optional[str]]
 ```
 
-Validates SSML, calls the plugin, and returns `(wav_path, phonemes_or_None)`.
-`kwargs` (typically `voice=` and `lang=`) are forwarded to the plugin. The WAV
-file is then passed to [`convert_audio()`](audio-formats.md) when a non-WAV
-output format is requested.
+Validates SSML, calls the plugin, and returns `(wav_path, phonemes_or_None)`. It forwards `kwargs` (typically `voice=` and `lang=`) to the plugin. The WAV file then passes to [`convert_audio()`](audio-formats.md) when a request asks for a non-WAV output format.
 
 Defined in `ovos_tts_server/__init__.py`.
 
 ## Languages
 
-`engine.langs` returns the plugin's `available_languages`, or a single-element
-list with the wrapper's default language (from config, global `lang`, or `mul`)
-when the plugin doesn't report any. It is surfaced by `GET /status`
-(`langs` / `default_lang`) and by the ElevenLabs `/v1/models` listing.
+`engine.langs` returns the plugin's `available_languages`, or a single-element list with the wrapper's default language (from config, global `lang`, or `mul`) when the plugin reports none. `GET /status` (`langs` / `default_lang`) and the ElevenLabs `/v1/models` listing surface this value.
 
 ## Voices
 
-`engine.voices` is populated from the loaded plugin's `available_voices`
-attribute, if present (a list of strings or dicts); otherwise it is empty.
-Routers that expose a voices listing (e.g. ElevenLabs `/v1/voices`) read this
-list directly and fall back to a single `"default"` entry when the plugin
-reports none.
+`engine.voices` is populated from the loaded plugin's `available_voices` attribute, if present (a list of strings or dicts). Otherwise it is empty. Routers that expose a voices listing (for example ElevenLabs `/v1/voices`) read this list directly and fall back to a single `"default"` entry when the plugin reports none.
+
+---
+[Home](index.md) · [API Compatibility →](api-compatibility.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,6 @@
-# ovos-tts-server — Architecture Overview
+# ovos-tts-server: Architecture Overview
 
-An HTTP server that exposes any OVOS TTS plugin as a REST service using
-[FastAPI](https://fastapi.tiangolo.com/). It is **stateless**: each request
-loads a plugin (once, at startup), calls it, and returns the generated audio.
+An HTTP server that exposes any OVOS TTS plugin as a REST service, using [FastAPI](https://fastapi.tiangolo.com/). It is stateless: each request loads a plugin (once, at startup), calls it, and returns the generated audio.
 
 For installation and usage, start with the [README](../README.md).
 
@@ -29,15 +27,14 @@ HTTP response (audio file / bytes / base64 JSON, per vendor)
 | Method | Path | Description |
 | :--- | :--- | :--- |
 | GET | `/status` | Plugin name, supported languages, default voice/model |
-| GET | `/v2/synthesize?utterance=<text>[&lang=…][&voice=…]` | Primary synthesis endpoint — returns WAV audio |
+| GET | `/v2/synthesize?utterance=<text>[&lang=...][&voice=...]` | Primary synthesis endpoint, returns WAV audio |
 | GET | `/synthesize/<utterance>` | Legacy path-based synthesis endpoint |
 
-Extra query parameters are forwarded to the plugin as synthesis options.
+The server forwards extra query parameters to the plugin as synthesis options.
 
 ## Compatibility routers
 
-Drop-in compatibility endpoints for popular cloud TTS APIs are registered
-alongside the native endpoints, each under its own URL prefix:
+The server registers drop-in compatibility endpoints for popular cloud TTS APIs alongside the native endpoints, each under its own URL prefix:
 
 | Vendor | Prefix |
 | :--- | :--- |
@@ -47,26 +44,20 @@ alongside the native endpoints, each under its own URL prefix:
 | Google Cloud TTS | `/google-tts` |
 | Amazon Polly | `/amazon-polly` |
 | Azure TTS | `/azure-tts` |
-| MaryTTS | `/marytts` (+ root aliases) |
+| MaryTTS | `/marytts` (plus root aliases) |
 | Cartesia | `/cartesia` |
 | Deepgram Aura | `/deepgram` |
 | PlayHT | `/playht` |
 
-Routers are wired up in `create_app()` (`ovos_tts_server/__init__.py`). An Azure
-WebSocket bridge router also exists but is not registered by default. See
-[api-compatibility.md](api-compatibility.md) for the full reference.
+`create_app()` (`ovos_tts_server/__init__.py`) wires up the routers. An Azure WebSocket bridge router also exists but is not registered by default. See [api-compatibility.md](api-compatibility.md) for the full reference.
 
-## Key classes & functions
+## Key classes and functions
 
 All defined in `ovos_tts_server/__init__.py`:
 
-- **`TTSEngineWrapper`** — loads and wraps a TTS plugin for dependency
-  injection; exposes `synthesize()`, `voices`, and `langs`.
-- **`create_app(tts_engine) -> FastAPI`** — factory that builds the FastAPI app,
-  wires the native endpoints and every compat router, and enables permissive
-  CORS.
-- **`start_tts_server(tts_plugin, cache=False) -> (FastAPI, TTSEngineWrapper)`** —
-  top-level entry point used by `__main__`; constructs the wrapper and the app.
+- **`TTSEngineWrapper`**: loads and wraps a TTS plugin for dependency injection. Exposes `synthesize()`, `voices`, and `langs`.
+- **`create_app(tts_engine) -> FastAPI`**: factory that builds the FastAPI app, wires the native endpoints and every compat router, and enables permissive CORS.
+- **`start_tts_server(tts_plugin, cache=False) -> (FastAPI, TTSEngineWrapper)`**: top-level entry point used by `__main__`. Constructs the wrapper and the app.
 
 ## Entry point
 
@@ -74,17 +65,14 @@ All defined in `ovos_tts_server/__init__.py`:
 ovos-tts-server --engine <plugin_name> [--host 0.0.0.0] [--port 9666] [--cache] [--lang en-us]
 ```
 
-`__main__.py` parses the CLI, calls `start_tts_server(...)`, and runs the app
-with `uvicorn`.
+`__main__.py` parses the CLI, calls `start_tts_server(...)`, and runs the app with `uvicorn`.
 
 ## CORS
 
-All origins are allowed unconditionally
-(`CORSMiddleware(allow_origins=["*"])`). Restrict this at your reverse proxy if
-the server is exposed publicly.
+The server allows all origins unconditionally (`CORSMiddleware(allow_origins=["*"])`). Restrict this at your reverse proxy if the server is exposed publicly.
 
 ## Documentation map
 
-- [API Compatibility Reference](api-compatibility.md) — every vendor prefix, endpoint, parameter, and SDK snippet
-- [Voice & Language Configuration](configuration.md) — how a request maps to the plugin
-- [Audio Format Conversion](audio-formats.md) — `convert_audio()` and the `[audio]` extra
+- [API Compatibility Reference](api-compatibility.md): every vendor prefix, endpoint, parameter, and SDK snippet
+- [Voice & Language Configuration](configuration.md): how a request maps to the plugin
+- [Audio Format Conversion](audio-formats.md): `convert_audio()` and the `[audio]` extra

--- a/docs/transformers.md
+++ b/docs/transformers.md
@@ -1,19 +1,13 @@
 # Transformer Pipelines
 
-The server can run OVOS transformer plugins around synthesis. Both hooks
-live in the engine wrapper, so **every** surface gets them: native
-endpoints, all vendor-compat routers, the websocket streaming routes, MCP
-and UTCP.
+The server can run OVOS transformer plugins around synthesis. Both hooks live in the engine wrapper, so every surface gets them: native endpoints, all vendor-compat routers, the websocket streaming routes, MCP, and UTCP.
 
-- **Dialog transformers** rewrite the utterance *text* before synthesis.
-- **TTS transformers** post-process the synthesized *audio* before it is
-  served. They run on a temp copy — the plugin's audio cache is never
-  mutated, so cache hits are never served pre-transformed audio.
+- **Dialog transformers** rewrite the utterance text before synthesis.
+- **TTS transformers** post-process the synthesized audio before the server serves it. They run on a temporary copy. The plugin's audio cache is never mutated, so cache hits never serve pre-transformed audio.
 
 ## Configuration
 
-Loading is config-gated and opt-in via the standard mycroft.conf sections;
-with no config the server behaves exactly as before:
+Loading is config-gated and opt-in, through the standard mycroft.conf sections. With no config, the server behaves exactly as before:
 
 ```json
 {
@@ -26,28 +20,18 @@ with no config the server behaves exactly as before:
 }
 ```
 
-Chains run in ascending priority order (OVOS-TRANSFORM §4); an explicit
-`"order"` list in a section wins over priorities. See the
-[ovos-plugin-manager transformer docs](https://github.com/OpenVoiceOS/ovos-plugin-manager/blob/dev/docs/transformers.md)
-for the full contract.
+Chains run in ascending priority order (OVOS-TRANSFORM §4). An explicit `"order"` list in a section wins over priorities. See the [ovos-plugin-manager transformer docs](https://github.com/OpenVoiceOS/ovos-plugin-manager/blob/dev/docs/transformers.md) for the full contract.
 
-## When to use — and the surprise factor
+## When to use a transformer
 
-A dialog transformer on the *server* means the server synthesizes
-**different text than the client sent**. From the client's perspective that
-is unexpected — a request for "the CPU is at 95 percent" comes back as
-audio saying something else. Do it on purpose:
+A dialog transformer on the server means the server synthesizes different text than the client sent. From the client's perspective that is unexpected: a request for "the CPU is at 95 percent" comes back as audio saying something else. Enable one on purpose, for a clear reason:
 
-- **Global tone/persona**: enable one dialog transformer here and every
-  device, app and vendor-SDK client that synthesizes through this server
-  gets the same voice personality, fleet-wide, with zero client changes.
-- **Global audio post-processing**: a tts transformer here applies the same
-  effect (pitch, speed, loudness normalization) to every response.
+- **Global tone or persona.** Enable one dialog transformer here and every device, app, and vendor-SDK client that synthesizes through this server gets the same voice personality, fleet-wide, with no client changes.
+- **Global audio post-processing.** A tts transformer here applies the same effect (pitch, speed, loudness normalization) to every response.
 
-If instead the effect should be **per-device** (one speaker needs a boost,
-one room needs a different pitch), run the transformer on that device
-(ovos-audio or a HiveMind satellite), not here — and never enable the same
-plugin on both sides, or it is applied twice.
+If the effect should instead apply per device (one speaker needs a boost, one room needs a different pitch), run the transformer on that device (ovos-audio or a HiveMind satellite), not here. Never enable the same plugin on both sides, or the server applies it twice.
 
-Note for the caching-inclined: dialog transformation happens *before* the
-TTS cache, so the cache keys on the transformed text and stays consistent.
+Dialog transformation happens before the TTS cache, so the cache keys on the transformed text and stays consistent.
+
+---
+[← API Compatibility](api-compatibility.md) · [Home](index.md) · [Audio Formats →](audio-formats.md)


### PR DESCRIPTION
Rewrites README.md and docs/*.md in Simplified Technical English for clarity: shorter sentences, active voice, no marketing language, no em dashes. Adds a navigation footer to the multi-page docs set (docs/index.md stays exempt as the map). Keeps every fact, code block, badge, and license section unchanged.

Rewritten by Claude Sonnet 5 using the ste-writing skill (authored and reviewed by Claude Fable 5); linted with ste_lint.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reworked the README and documentation pages for clearer, more consistent wording and formatting.
  * Clarified configuration, plugin loading, caching, parameter forwarding, language fallback, voice discovery, and audio conversion behavior.
  * Expanded API compatibility guidance, including supported vendors, authentication handling, and parameter details.
  * Documented audio-format behavior, transformer usage guidance, and navigation links across related topics.
  * Confirmed documented endpoint and integration behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->