### PR TITLE
fix: run blocking synth off the event loop in elevenlabs websocket stream

### DIFF
--- a/ovos_tts_server/mcp_server.py
+++ b/ovos_tts_server/mcp_server.py
@@ -34,6 +34,8 @@ import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
+from starlette.concurrency import run_in_threadpool
+
 if TYPE_CHECKING:
     from fastapi import FastAPI
     from ovos_tts_server import TTSEngineWrapper
@@ -67,7 +69,7 @@ def _build_mcp(engine: "TTSEngineWrapper"):
             "Returns base64-encoded WAV audio with MIME type audio/wav."
         ),
     )
-    def synthesize(
+    async def synthesize(
         text: str,
         voice: Optional[str] = None,
         lang: Optional[str] = None,
@@ -95,10 +97,13 @@ def _build_mcp(engine: "TTSEngineWrapper"):
         if lang:
             kwargs["lang"] = lang
 
-        audio_path, phonemes = engine.synthesize(text, **kwargs)
+        audio_path, phonemes = await run_in_threadpool(engine.synthesize, text, **kwargs)
 
-        with open(audio_path, "rb") as fh:
-            audio_bytes = fh.read()
+        def _read_audio() -> bytes:
+            with open(audio_path, "rb") as fh:
+                return fh.read()
+
+        audio_bytes = await run_in_threadpool(_read_audio)
 
         return {
             "mime_type": "audio/wav",

--- a/ovos_tts_server/routers/azure_ws.py
+++ b/ovos_tts_server/routers/azure_ws.py
@@ -188,7 +188,7 @@ def make_azure_ws_router(engine) -> APIRouter:
                     ssml = str(body)
                     utterance, synth_kwargs = _extract_synth_args(ssml)
                     wav_path, _ = await run_in_threadpool(engine.synthesize, utterance, **synth_kwargs)
-                    audio_bytes, mime = convert_audio(wav_path, output_format)
+                    audio_bytes, mime = await run_in_threadpool(convert_audio, wav_path, output_format)
 
                     # turn.start
                     await websocket.send_text(_build_text(

--- a/ovos_tts_server/routers/elevenlabs.py
+++ b/ovos_tts_server/routers/elevenlabs.py
@@ -48,6 +48,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 from fastapi import APIRouter, Header, Query, WebSocket, WebSocketDisconnect
 from fastapi.responses import Response
 from pydantic import BaseModel, Field
+from starlette.concurrency import run_in_threadpool
 
 from ovos_tts_server.audio_utils import _ensure_wav, convert_audio
 
@@ -389,8 +390,8 @@ def make_elevenlabs_router(engine) -> APIRouter:
             buffer.clear()
             if not text:
                 return
-            audio_path, _ = engine.synthesize(text, **synth_kwargs)
-            audio_bytes, _mime = encode_audio(audio_path, output_format)
+            audio_path, _ = await run_in_threadpool(engine.synthesize, text, **synth_kwargs)
+            audio_bytes, _mime = await run_in_threadpool(encode_audio, audio_path, output_format)
             for start in range(0, len(audio_bytes), AUDIO_CHUNK_SIZE):
                 chunk = audio_bytes[start:start + AUDIO_CHUNK_SIZE]
                 await websocket.send_json(_audio_frame(

--- a/test/unittests/test_concurrency.py
+++ b/test/unittests/test_concurrency.py
@@ -1,0 +1,339 @@
+# Licensed under the Apache License, Version 2.0
+"""Regression tests: the event loop must stay free during synthesis.
+
+``synthesize()`` is a blocking call. If a request handler awaits it directly
+on the event loop (instead of running it in a worker thread), the whole
+server stalls for the duration of synthesis: concurrent synthesis requests
+serialize instead of overlapping, and unrelated endpoints like ``/status``
+cannot be answered until the in-flight synthesis finishes.
+
+This was observed on a live deployment: during a single cold-voice
+synthesis, ``GET /status`` did not respond within 30s (repeated 3x) while
+container CPU sat at 0.59%, proving the event loop -- not the CPU -- was the
+bottleneck.
+
+These tests use a real concurrent client (httpx.AsyncClient over
+ASGITransport) and asyncio.gather so a still-blocking handler actually fails
+the assertions, rather than a sync TestClient which cannot observe
+event-loop stalls.
+
+Tests are plain sync functions that drive their own asyncio.run(...) so
+they do not depend on the pytest-asyncio plugin being autoloaded (this repo
+runs pytest with PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 to avoid clashing
+plugins in the shared venv).
+"""
+import asyncio
+import tempfile
+import threading
+import time
+import wave
+from typing import List, Optional, Tuple
+from unittest.mock import patch
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from ovos_tts_server import create_app
+from ovos_tts_server.routers import elevenlabs as elevenlabs_mod
+from ovos_tts_server.routers.elevenlabs import make_elevenlabs_router
+
+SLEEP_SECONDS = 2.0
+
+
+def run_async(coro_fn, *args, **kwargs):
+    """Run an async test body without relying on the pytest-asyncio plugin."""
+    return asyncio.run(coro_fn(*args, **kwargs))
+
+
+def _write_wav(path: str) -> None:
+    with wave.open(path, "w") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(16000)
+        wf.writeframes(b"\x00\x00" * 100)
+
+
+class SlowEngine:
+    """Stand-in for TTSEngineWrapper whose synthesize() blocks for a while.
+
+    Mimics a real cold-voice synthesis: CPU-cheap but wall-clock slow
+    (e.g. waiting on a model load or a subprocess), which is exactly the
+    shape that exposes an event-loop stall.
+    """
+
+    plugin_name: str = "slow-fake-tts"
+    lang: str = "en-us"
+    langs: List[str] = ["en-us"]
+    voices: List[str] = ["voice1"]
+
+    def __init__(self, sleep_seconds: float = SLEEP_SECONDS):
+        self.sleep_seconds = sleep_seconds
+        self.calls: List[Tuple[str, dict, float]] = []
+
+        class _InnerEngine:
+            config = {"model": "fakemodel", "voice": "fakevoice"}
+
+        self.engine = _InnerEngine()
+
+    def synthesize(self, utterance: str, **kwargs) -> Tuple[str, Optional[str]]:
+        start = time.monotonic()
+        time.sleep(self.sleep_seconds)  # blocking, deliberately not asyncio.sleep
+        self.calls.append((utterance, kwargs, start))
+        tmp = tempfile.NamedTemporaryFile(suffix=".wav", delete=False)
+        tmp.close()
+        _write_wav(tmp.name)
+        return tmp.name, None
+
+
+@pytest.fixture
+def engine() -> SlowEngine:
+    return SlowEngine()
+
+
+class TestServerStaysResponsiveDuringSynthesis:
+    """The /v2/synthesize and legacy /synthesize handlers must not block
+    the event loop -- other requests must be served while synthesis runs.
+    """
+
+    def test_status_answers_promptly_during_synthesis(self, engine):
+        async def _run():
+            app = create_app(engine)
+            transport = httpx.ASGITransport(app=app)
+            async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+                synth_task = asyncio.create_task(
+                    client.get("/v2/synthesize", params={"utterance": "hello"})
+                )
+                # Give the synth request a head start so it is in flight.
+                await asyncio.sleep(0.2)
+
+                start = time.monotonic()
+                status_resp = await client.get("/status")
+                elapsed = time.monotonic() - start
+
+                synth_resp = await synth_task
+            return status_resp, synth_resp, elapsed
+
+        status_resp, synth_resp, elapsed = run_async(_run)
+
+        assert status_resp.status_code == 200
+        assert synth_resp.status_code == 200
+        # If the loop were blocked by synthesize(), /status would only
+        # answer after the ~2s sleep finished.
+        assert elapsed < SLEEP_SECONDS / 2, (
+            f"/status took {elapsed:.2f}s while synthesis was in flight -- "
+            "the event loop is blocked"
+        )
+
+    def test_legacy_synthesize_does_not_block_status(self, engine):
+        async def _run():
+            app = create_app(engine)
+            transport = httpx.ASGITransport(app=app)
+            async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+                synth_task = asyncio.create_task(client.get("/synthesize/hello"))
+                await asyncio.sleep(0.2)
+
+                start = time.monotonic()
+                status_resp = await client.get("/status")
+                elapsed = time.monotonic() - start
+
+                await synth_task
+            return status_resp, elapsed
+
+        status_resp, elapsed = run_async(_run)
+
+        assert status_resp.status_code == 200
+        assert elapsed < SLEEP_SECONDS / 2
+
+    def test_two_concurrent_synth_requests_overlap(self, engine):
+        """Two synthesis calls should run concurrently, not serialize.
+
+        With a blocking event loop, request B's call to synthesize() cannot
+        even start until request A's synthesize() call returns, so B's
+        start time would be >= A's finish time. With the fix, both worker
+        threads run the blocking call in parallel, so B starts before A
+        finishes.
+        """
+        async def _run():
+            app = create_app(engine)
+            transport = httpx.ASGITransport(app=app)
+            async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+                overall_start = time.monotonic()
+                await asyncio.gather(
+                    client.get("/v2/synthesize", params={"utterance": "a"}),
+                    client.get("/v2/synthesize", params={"utterance": "b"}),
+                )
+                overall_elapsed = time.monotonic() - overall_start
+            return overall_elapsed
+
+        overall_elapsed = run_async(_run)
+
+        # Serialized: ~2 * SLEEP_SECONDS. Overlapped: ~SLEEP_SECONDS. Since
+        # overall_elapsed can never go below SLEEP_SECONDS, comparing against
+        # a multiple of SLEEP_SECONDS leaves only ~1.0s of headroom on a
+        # shared CI runner. Assert on the discriminating quantity instead:
+        # overlapped ~= 0 extra seconds, serialized ~= +SLEEP_SECONDS extra.
+        assert overall_elapsed - SLEEP_SECONDS < 0.5, (
+            f"two concurrent synth requests took {overall_elapsed:.2f}s -- "
+            "they serialized instead of overlapping"
+        )
+        assert len(engine.calls) == 2
+        start_a, start_b = sorted(c[2] for c in engine.calls)
+        # B must start before A finishes (A's start + sleep_seconds).
+        assert start_b < start_a + engine.sleep_seconds
+
+
+class TestVendorRouterStaysResponsiveDuringSynthesis:
+    """Same property, exercised through a vendor-compat router.
+
+    ElevenLabs HTTP handlers are declared as plain ``def``, which FastAPI
+    runs in a threadpool automatically -- but the websocket streaming
+    handler contains a nested ``async def generate()`` that must explicitly
+    hand the blocking call off to a worker thread, or it stalls the socket
+    loop.
+    """
+
+    @pytest.fixture
+    def app(self, engine):
+        app = FastAPI()
+        app.include_router(make_elevenlabs_router(engine))
+        return app
+
+    def test_http_tts_endpoint_requests_overlap(self, app, engine):
+        async def _run():
+            transport = httpx.ASGITransport(app=app)
+            async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+                overall_start = time.monotonic()
+                await asyncio.gather(
+                    client.post(
+                        "/elevenlabs/v1/text-to-speech/default",
+                        json={"text": "hello world"},
+                    ),
+                    client.post(
+                        "/elevenlabs/v1/text-to-speech/default",
+                        json={"text": "second call"},
+                    ),
+                )
+                overall_elapsed = time.monotonic() - overall_start
+            return overall_elapsed
+
+        overall_elapsed = run_async(_run)
+
+        assert overall_elapsed - SLEEP_SECONDS < 0.5, (
+            f"two concurrent elevenlabs requests took {overall_elapsed:.2f}s "
+            "-- they serialized instead of overlapping"
+        )
+
+    def test_stream_input_websocket_does_not_block_concurrent_http_call(self, engine):
+        """The websocket generate() must not stall a concurrent HTTP request
+        served by the same app/event loop.
+
+        ``with TestClient(app) as client:`` (entering the client itself,
+        not just a single ``websocket_connect()``) keeps ONE anyio portal
+        -- and therefore one shared event loop -- alive for every call made
+        inside the block. A plain ``client.post(...)`` made outside such a
+        block gets its own throwaway portal/loop and would never observe a
+        stall on the websocket's loop, so it would not be a valid
+        regression test; calls must share the portal for this to prove
+        anything.
+        """
+        from fastapi.testclient import TestClient
+
+        full_app = FastAPI()
+        full_app.include_router(make_elevenlabs_router(engine))
+
+        results = {}
+
+        with TestClient(full_app) as client:
+            def do_http_call():
+                time.sleep(0.2)  # let the websocket generation start first
+                start = time.monotonic()
+                resp = client.post(
+                    "/elevenlabs/v1/text-to-speech/default",
+                    json={"text": "concurrent http call"},
+                )
+                results["elapsed"] = time.monotonic() - start
+                results["status_code"] = resp.status_code
+
+            thread = threading.Thread(target=do_http_call)
+            thread.start()
+
+            with client.websocket_connect(
+                    "/elevenlabs/v1/text-to-speech/default/stream-input") as ws:
+                ws.send_json({"text": " "})
+                ws.send_json({"text": "hello"})
+                ws.send_json({"text": ""})
+                while True:
+                    frame = ws.receive_json()
+                    if frame["isFinal"]:
+                        break
+
+            thread.join()
+
+        assert results["status_code"] == 200
+        assert results["elapsed"] < SLEEP_SECONDS * 1.5, (
+            f"concurrent HTTP call took {results['elapsed']:.2f}s while the "
+            "websocket's synthesize() was in flight -- the event loop is "
+            "blocked"
+        )
+
+    def test_stream_input_encode_audio_does_not_block_concurrent_http_call(self, engine):
+        """The websocket generate() must not stall on a slow encode_audio()
+        call either -- not just a slow synthesize() call.
+
+        The default ``stream-input`` output_format is
+        ``DEFAULT_OUTPUT_FORMAT`` ("mp3_44100_128"), which drives a real
+        pydub/ffmpeg mp3 export inside ``encode_audio``. A 100-frame test wav
+        makes that export essentially free, which would let a regression
+        where ``encode_audio`` runs inline on the event loop slip past
+        ``test_stream_input_websocket_does_not_block_concurrent_http_call``
+        undetected. Here ``engine.synthesize`` is fast (sleep_seconds=0) and
+        ``encode_audio`` is patched to block for SLEEP_SECONDS, isolating the
+        encode step as the only possible source of a stall.
+        """
+        from fastapi.testclient import TestClient
+
+        fast_engine = type(engine)(sleep_seconds=0.0)
+
+        full_app = FastAPI()
+        full_app.include_router(make_elevenlabs_router(fast_engine))
+
+        def _slow_encode_audio(*args, **kwargs):
+            time.sleep(SLEEP_SECONDS)  # blocking, deliberately not asyncio.sleep
+            return b"\x00" * 16, "audio/mpeg"
+
+        results = {}
+
+        with patch.object(elevenlabs_mod, "encode_audio", side_effect=_slow_encode_audio):
+            with TestClient(full_app) as client:
+                def do_http_call():
+                    time.sleep(0.2)  # let the websocket generation start first
+                    start = time.monotonic()
+                    resp = client.post(
+                        "/elevenlabs/v1/text-to-speech/default",
+                        json={"text": "concurrent http call"},
+                    )
+                    results["elapsed"] = time.monotonic() - start
+                    results["status_code"] = resp.status_code
+
+                thread = threading.Thread(target=do_http_call)
+                thread.start()
+
+                with client.websocket_connect(
+                        "/elevenlabs/v1/text-to-speech/default/stream-input") as ws:
+                    ws.send_json({"text": " "})
+                    ws.send_json({"text": "hello"})
+                    ws.send_json({"text": ""})
+                    while True:
+                        frame = ws.receive_json()
+                        if frame["isFinal"]:
+                            break
+
+                thread.join()
+
+        assert results["status_code"] == 200
+        assert results["elapsed"] < SLEEP_SECONDS * 1.5, (
+            f"concurrent HTTP call took {results['elapsed']:.2f}s while the "
+            "websocket's encode_audio() was in flight -- the event loop is "
+            "blocked"
+        )

--- a/test/unittests/test_mcp_server.py
+++ b/test/unittests/test_mcp_server.py
@@ -4,6 +4,7 @@
 The ``mcp`` package is mocked throughout so these tests run without it
 being installed.
 """
+import asyncio
 import base64
 import sys
 import types
@@ -124,7 +125,7 @@ class TestBuildMcp:
     def test_synthesize_returns_expected_keys(self, engine, fake_mcp_modules):
         mcp_server_mod, tools = fake_mcp_modules
         mcp_server_mod._build_mcp(engine)
-        result = tools["synthesize"](text="hello world")
+        result = asyncio.run(tools["synthesize"](text="hello world"))
         assert "mime_type" in result
         assert "data" in result
         assert "path" in result
@@ -133,39 +134,39 @@ class TestBuildMcp:
     def test_synthesize_mime_type_is_wav(self, engine, fake_mcp_modules):
         mcp_server_mod, tools = fake_mcp_modules
         mcp_server_mod._build_mcp(engine)
-        result = tools["synthesize"](text="hello")
+        result = asyncio.run(tools["synthesize"](text="hello"))
         assert result["mime_type"] == "audio/wav"
 
     def test_synthesize_data_is_valid_base64(self, engine, fake_mcp_modules):
         mcp_server_mod, tools = fake_mcp_modules
         mcp_server_mod._build_mcp(engine)
-        result = tools["synthesize"](text="hello")
+        result = asyncio.run(tools["synthesize"](text="hello"))
         decoded = base64.b64decode(result["data"])
         assert len(decoded) > 0
 
     def test_synthesize_with_voice_param(self, engine, fake_mcp_modules):
         mcp_server_mod, tools = fake_mcp_modules
         mcp_server_mod._build_mcp(engine)
-        result = tools["synthesize"](text="hello", voice="voice1")
+        result = asyncio.run(tools["synthesize"](text="hello", voice="voice1"))
         assert result["mime_type"] == "audio/wav"
 
     def test_synthesize_with_lang_param(self, engine, fake_mcp_modules):
         mcp_server_mod, tools = fake_mcp_modules
         mcp_server_mod._build_mcp(engine)
-        result = tools["synthesize"](text="hello", lang="de-de")
+        result = asyncio.run(tools["synthesize"](text="hello", lang="de-de"))
         assert result["mime_type"] == "audio/wav"
 
     def test_synthesize_empty_text_raises(self, engine, fake_mcp_modules):
         mcp_server_mod, tools = fake_mcp_modules
         mcp_server_mod._build_mcp(engine)
         with pytest.raises(ValueError, match="non-empty"):
-            tools["synthesize"](text="")
+            asyncio.run(tools["synthesize"](text=""))
 
     def test_synthesize_whitespace_text_raises(self, engine, fake_mcp_modules):
         mcp_server_mod, tools = fake_mcp_modules
         mcp_server_mod._build_mcp(engine)
         with pytest.raises(ValueError, match="non-empty"):
-            tools["synthesize"](text="   ")
+            asyncio.run(tools["synthesize"](text="   "))
 
     def test_build_raises_import_error_when_mcp_missing(self, engine):
         """_build_mcp should raise ImportError when mcp is not installed."""
@@ -274,7 +275,7 @@ class TestSynthesizeEdgeCases:
         mcp_server_mod, tools = fake_mcp_modules
         mcp_server_mod._build_mcp(engine)
         long_text = "word " * 2000
-        result = tools["synthesize"](text=long_text)
+        result = asyncio.run(tools["synthesize"](text=long_text))
         assert result["mime_type"] == "audio/wav"
         decoded = base64.b64decode(result["data"])
         assert len(decoded) > 0
@@ -283,7 +284,7 @@ class TestSynthesizeEdgeCases:
         """Decoded base64 data must start with the RIFF WAV magic bytes."""
         mcp_server_mod, tools = fake_mcp_modules
         mcp_server_mod._build_mcp(engine)
-        result = tools["synthesize"](text="check wav header")
+        result = asyncio.run(tools["synthesize"](text="check wav header"))
         decoded = base64.b64decode(result["data"])
         assert decoded[:4] == b"RIFF", (
             f"Expected WAV RIFF header, got: {decoded[:4]!r}"
@@ -293,27 +294,27 @@ class TestSynthesizeEdgeCases:
         """Passing an unknown voice should not raise — FakeEngine ignores extra kwargs."""
         mcp_server_mod, tools = fake_mcp_modules
         mcp_server_mod._build_mcp(engine)
-        result = tools["synthesize"](text="hello", voice="nonexistent-voice")
+        result = asyncio.run(tools["synthesize"](text="hello", voice="nonexistent-voice"))
         assert result["mime_type"] == "audio/wav"
 
     def test_unknown_lang_forwarded_to_engine(self, engine, fake_mcp_modules):
         """Passing an unknown lang should not raise — FakeEngine ignores extra kwargs."""
         mcp_server_mod, tools = fake_mcp_modules
         mcp_server_mod._build_mcp(engine)
-        result = tools["synthesize"](text="hello", lang="xx-yy")
+        result = asyncio.run(tools["synthesize"](text="hello", lang="xx-yy"))
         assert result["mime_type"] == "audio/wav"
 
     def test_phonemes_field_is_none_when_engine_returns_none(self, engine, fake_mcp_modules):
         mcp_server_mod, tools = fake_mcp_modules
         mcp_server_mod._build_mcp(engine)
-        result = tools["synthesize"](text="phoneme check")
+        result = asyncio.run(tools["synthesize"](text="phoneme check"))
         assert result["phonemes"] is None
 
     def test_path_field_points_to_existing_file(self, engine, fake_mcp_modules):
         import os
         mcp_server_mod, tools = fake_mcp_modules
         mcp_server_mod._build_mcp(engine)
-        result = tools["synthesize"](text="path check")
+        result = asyncio.run(tools["synthesize"](text="path check"))
         assert os.path.isfile(result["path"]), f"Expected file at {result['path']!r}"
 
 


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Sonnet 5 (claude-sonnet-5) via Claude Code — NOT human-reviewed. Verify before acting.

An async request handler that calls blocking code runs that code directly on the event loop, and while it runs the server answers nothing else at all — not other requests, not even /status. This was observed live: GET /status went unanswered for 30 seconds, three times in a row, during a single synthesis, while container CPU sat at 0.59%, which is what proved it was the event loop stalling and not the CPU actually being busy.

An earlier version of this PR fixed only one of four blocking paths that cause this. This revision fixes all four. The elevenlabs stream-input websocket handler had its engine.synthesize() call wrapped in run_in_threadpool already, but three lines later encode_audio() still ran inline — a full file read plus a pydub/ffmpeg mp3 export for the default output format, and sometimes a synchronous ffmpeg subprocess call too, measured at a 0.58 second event-loop stall per 120 seconds of audio, scaling with length. The azure_ws.py handler had the same problem: convert_audio() ran inline right after an already-threadpooled synthesize call. And the MCP synthesize tool was a plain sync function calling synthesize() and reading a file — the MCP SDK calls sync tools directly on the event loop, and because the MCP app is mounted onto the same FastAPI app as everything else, one MCP synthesize call froze /status and every other endpoint for the whole synthesis. That last one is the exact symptom seen in production, measured at a full 2.0 second event-loop stall for a simulated synthesis.

All four now hand their blocking work to starlette.concurrency.run_in_threadpool. The MCP tool became async def. This doesn't change any response shape, status code, or public API — it only changes where the blocking work actually runs. Making the MCP tool async was checked against the installed mcp package to confirm the SDK awaits async tools correctly; the only other caller of that tool was the unit test, which was updated to call it through asyncio.run at all 13 call sites.

Every one of the four fixes was verified by reverting it in isolation (file copied aside and restored, never git stash, which isn't safe across worktrees on this box) and rerunning the relevant check. Reverting the encode_audio fix made the new concurrency test fail (3.83s where it expects under 3.0s) and pass once restored. Reverting the azure convert_audio fix made a concurrent request take 1.84 seconds instead of 0.005. Reverting the MCP fix meant a second concurrent task didn't complete until the full 2.0 second synthesis finished, instead of completing after about 0.2 seconds.

test/unittests is 187 passed, up from a baseline of 186 with the one new regression test added. Three integration test files fail to collect for missing optional dependencies (cartesia, pyht) — pre-existing and unrelated to this change. The branch was squashed to a single commit on top of dev and force-pushed.
