### PR TITLE
fix(openai): accept pathlib paths in audio conversion

### DIFF
--- a/ovos_tts_server/audio_utils.py
+++ b/ovos_tts_server/audio_utils.py
@@ -9,7 +9,7 @@ from typing import Tuple
 def _is_wav(path: str) -> bool:
     """Return True if the file can be opened as a RIFF WAV."""
     try:
-        with wave.open(path, "rb"):
+        with wave.open(os.fspath(path), "rb"):
             return True
     except (wave.Error, EOFError, OSError):
         return False

--- a/test/unittests/test_audio_utils.py
+++ b/test/unittests/test_audio_utils.py
@@ -6,6 +6,7 @@ import os
 import sys
 import tempfile
 import wave
+from pathlib import Path
 
 import pytest
 
@@ -31,6 +32,12 @@ def wav_path() -> str:
 class TestConvertAudio:
     def test_wav_passthrough(self, wav_path):
         data, mime = convert_audio(wav_path, "wav")
+        assert mime == "audio/wav"
+        assert data.startswith(b"RIFF")
+
+    def test_accepts_pathlib_path(self, wav_path):
+        """The OpenAI speech route hands convert_audio a pathlib.Path; it must not 500."""
+        data, mime = convert_audio(Path(wav_path), "wav")
         assert mime == "audio/wav"
         assert data.startswith(b"RIFF")
 


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

POST /openai/v1/audio/speech returns a 500 on the public demo (ovos-tts-server==1.14.1a2). The local traceback is `AttributeError: 'PosixPath' object has no attribute 'read'`, raised from `wave.py` inside `_is_wav()` in `ovos_tts_server/audio_utils.py`.

The OpenAI-compatible route hands `convert_audio()` the path returned by `engine.synthesize(...)`, which can be a `pathlib.Path`. `_is_wav()` passes that straight into `wave.open()`. CPython's `wave.open` only special-cases `str` for the "open by filename" code path; anything else, including a `PosixPath`, falls through to the "treat as an already-open file object" branch, and `wave._Chunk` then calls `path.read(4)`, which `PosixPath` doesn't have.

The fix coerces the path with `os.fspath()` before handing it to `wave.open()` in `_is_wav()`. That's the only `wave.open`/file-object call in `audio_utils.py` that assumed a string; `open()` and `AudioSegment.from_file()` elsewhere already accept path-like objects fine.

Added a regression test in `test/unittests/test_audio_utils.py` that calls `convert_audio()` with a `pathlib.Path` input. Before the fix it failed with the exact `AttributeError` reproduced above; after the fix it passes. The rest of `test/unittests/test_audio_utils.py` (9/9) and the full unit suite (186/188, with the 2 pre-existing `test_mcp_server.py` failures caused by the optional `mcp` extra not being installed, unrelated to this change) were run and pass.