### PR TITLE
docs: correct --lang CLI default

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ ovos-tts-server [-h] [--engine ENGINE] [--port PORT] [--host HOST] [--cache] [--
 | `--port PORT` | `9666` | Port to bind |
 | `--host HOST` | `0.0.0.0` | Host/interface to bind |
 | `--cache` | off | Persist every synth to disk (cache across requests) |
-| `--lang LANG` | `en-us` | Default language reported by the plugin |
+| `--lang LANG` | none | Overrides the plugin's configured language; falls back to the plugin's own configuration, or `mul`, when omitted |
 
 ## Configuration
 


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Sonnet 5 (claude-sonnet-5) via Claude Code — NOT human-reviewed. Verify before acting.

The README's command-line table listed `en-us` as the default for `--lang`. Checked against current source: `ovos_tts_server/__main__.py` defines `--lang` with `default=None`, and `TTSEngineWrapper.__init__` (`ovos_tts_server/__init__.py`) only applies an explicit `lang` as an override — when it is not set, the wrapper falls back to the plugin's configured language, then `Configuration().get("lang")`, then the literal string `"mul"`. `en-us` never appears in that fallback chain. Updated the table row to describe the actual default and fallback order.